### PR TITLE
Web Scraper for Teraanga Commons Dining Hall

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.0
 Flask-CORS==4.0.0
 python-dotenv==1.0.0
+requests==2.32.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.0.0
 Flask-CORS==4.0.0
 python-dotenv==1.0.0
 requests==2.32.3
+flake8==7.1.1

--- a/backend/web-scraping/cafFoodInfo.csv
+++ b/backend/web-scraping/cafFoodInfo.csv
@@ -1,0 +1,184 @@
+Food Item,Dining Location,Cost,Calories,Nuts,Vegan,Gluten Free,Halal,Vegetarian,No Dairy,Comments,Eggs,Fish,Milk,Peanuts,Sesame,Shellfish,Soy,TreeNuts,Wheat,Kosher,Last Updated
+Cajun Chicken Thigh,Teraanga Commons Dining Hall,,210,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Plain Pancake,Teraanga Commons Dining Hall,,150,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Bacon Cheeseburger Pizza,Teraanga Commons Dining Hall,,210,,F,F,F,F,,"ground beef, bacon, red onion, mozzarella, 3 cheese blend",,,,,,,,,,F,10/06/2025
+BBQ Tofu Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,T,,"tofu, red onion, cilantro, BBQ tomato base, mozzarella",,,,,,,,,,F,10/06/2025
+Buffalo Chicken Pizza,Teraanga Commons Dining Hall,,180,,F,F,F,F,,"spicy buffalo chicken, red onion, buffalo sauce, mozzarella, blue cheese",,,,,,,,,,F,10/06/2025
+Canadian Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,F,,"pepperoni, bacon, mushroom, mozzarella",,,,,,,,,,F,10/06/2025
+Cheese Pizza,Teraanga Commons Dining Hall,,150,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Grilled Eggplant Pizza,Teraanga Commons Dining Hall,,180,,F,F,F,T,,"grilled eggplant, black olives, basil, chili pepper flakes, mozzarella",,,,,,,,,,F,10/06/2025
+Hawaiian Pizza,Teraanga Commons Dining Hall,,170,,F,F,F,F,,"ham, pineapple, mozzarella",,,,,,,,,,F,10/06/2025
+Jalapeno Popper Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,F,,"cream cheese, jalapeno peppers, red onions, monterey jack, bacon",,,,,,,,,,F,10/06/2025
+Margherita Pizza,Teraanga Commons Dining Hall,,170,,F,F,F,T,,"tomato, fresh basil, mozzarella, ricotta",,,,,,,,,,F,10/06/2025
+Mushroom & Caramelized Onion Pizza,Teraanga Commons Dining Hall,,200,,F,F,F,F,,"mushroom, caramelized onion, parsley, alfredo base, mozzarella, parmesan",,,,,,,,,,F,10/06/2025
+Pepperoni Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Sweet Potato and Caramelized Onion Pizza,Teraanga Commons Dining Hall,,560,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Sausage Round,Teraanga Commons Dining Hall,,160,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Onion Rings,Teraanga Commons Dining Hall,,180,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Orange Cremcicle Cake,Teraanga Commons Dining Hall,,310,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Lemon Cookie,Teraanga Commons Dining Hall,,70,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Pita Chips,Teraanga Commons Dining Hall,,25,,T,F,F,T,,,,,,,,,,,,F,10/06/2025
+Fattoush Salad,Teraanga Commons Dining Hall,,60,,F,F,F,F,,"pita croutons, lettuce, cucumber, tomato, green pepper, red onion, lemon vinaigrette",,,,,,,,,,F,10/06/2025
+Cream of spinach soup,Teraanga Commons Dining Hall,,,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+GF Broccoli Cheddar Soup,Teraanga Commons Dining Hall,,,,F,F,F,F,,A thick and delicious cheese soup with onions and broccoli florets.,,,,,,,,,,F,10/06/2025
+Goat Cheese & Vegetable Baguette,Teraanga Commons Dining Hall,,250,,F,F,F,F,,"mushroom, caramelized onion, spinach, zucchini, sundried tomato goat cheese",,,,,,,,,,F,10/06/2025
+Hot Beef Sandwich,Teraanga Commons Dining Hall,,400,,F,F,F,F,,"roast beef, onion, mushroom,  gravy, bun",,,,,,,,,,F,10/06/2025
+Smoked Meat Sandwich,Teraanga Commons Dining Hall,,390,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Smoked Turkey Sandwich,Teraanga Commons Dining Hall,,620,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Baked Chicken Thighs,Teraanga Commons Dining Hall,,,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Lentil Shepherd's Pie,Teraanga Commons Dining Hall,,150,,T,F,F,T,,"lentils, carrot, celery, gravy, spices, mashed potato",,,,,,,,,,F,10/06/2025
+Chickpea Panzanella Ricotta Salad,Teraanga Commons Dining Hall,,340,,F,F,F,F,,"crispy pesto chickpeas, ricotta, kalamata olives, cucumber, tomato, celery, red pepper, capers, balsamic glaze",,,,,,,,,,F,10/06/2025
+Poutine,Teraanga Commons Dining Hall,,370,,F,F,F,F,,"cheddar cheese curds, french fries, gravy",,,,,,,,,,F,10/06/2025
+Spicy Chicken Noodle Bowl,Teraanga Commons Dining Hall,,160,,F,F,F,F,,"gochujang chicken, spicy cucumber, green onion, sesame seeds, kimchi, udon noodles",,,,,,,,,,F,10/06/2025
+Pita Chips (1  kilogram),Teraanga Commons Dining Hall,,,,T,F,F,T,,,,,,,,,,,,F,10/06/2025
+Grilled Ham,Teraanga Commons Dining Hall,,30,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Peameal Bacon,Teraanga Commons Dining Hall,,45,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Turkey Breakfast Sausage,Teraanga Commons Dining Hall,,30,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Chicken Pho,Teraanga Commons Dining Hall,,410,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Miso Broth (356  millilitre),Teraanga Commons Dining Hall,,80,,T,F,F,T,,,,,,,,,,,,F,10/06/2025
+Shoyu Pork Broth (26520  millilitre),Teraanga Commons Dining Hall,,120,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Veggie Pho (200  gram),Teraanga Commons Dining Hall,,130,,T,T,F,T,,"tofu, onion, mushroom, pho vegetable broth, rice noodles, cilantro, green onion",,,,,,,,,,F,10/06/2025
+Blondie,Teraanga Commons Dining Hall,,310,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Chocolate Chip Rice Krispie Square,Teraanga Commons Dining Hall,,100,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Confetti Rice Krispie Square,Teraanga Commons Dining Hall,,90,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Mint Fudge,Teraanga Commons Dining Hall,,220,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Mixed Berry Oat Bar,Teraanga Commons Dining Hall,,190,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Rice Krispie Square,Teraanga Commons Dining Hall,,80,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Salted Caramel Brownie,Teraanga Commons Dining Hall,,230,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+S'mores Brownie,Teraanga Commons Dining Hall,,200,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Strawberry Brownie,Teraanga Commons Dining Hall,,290,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+WOW Butter Chocolate Fudge,Teraanga Commons Dining Hall,,300,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Seasoned Ground Beef,Teraanga Commons Dining Hall,,150,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Black Forest Cake,Teraanga Commons Dining Hall,,190,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Lemon Buttermilk Cake,Teraanga Commons Dining Hall,,140,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Vegan Marble Cake,Teraanga Commons Dining Hall,,210,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Vegan No Gluten Chocolate Cake,Teraanga Commons Dining Hall,,150,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Chicken & Corn Chowder,Teraanga Commons Dining Hall,,,,F,F,F,F,,"A creamy chowder loaded with chicken breast pieces, corn and potatoes.",,,,,,,,,,F,10/06/2025
+Club Sandwich,Teraanga Commons Dining Hall,,250,,F,F,F,F,,"bacon, ham, turkey, lettuce, tomato, cheddar cheese, mayo, whole wheat bread",,,,,,,,,,F,10/06/2025
+Alfredo Sauce (3000  millilitre),Teraanga Commons Dining Hall,,,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Braised Beef Ragu (3000  millilitre),Teraanga Commons Dining Hall,,160,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Marinara Sauce (3000  millilitre),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Salsa (3  litre),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Vanilla Cupcake,Teraanga Commons Dining Hall,,310,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Chocolate Chip Cookie,Teraanga Commons Dining Hall,,130,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Double Chocolate Cookie,Teraanga Commons Dining Hall,,160,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Oatmeal Raisin Cookie,Teraanga Commons Dining Hall,,120,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Sugar Cookie,Teraanga Commons Dining Hall,,110,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Asian Noodle Salad (1000  gram),Teraanga Commons Dining Hall,,,,F,F,F,T,,"rice noodles, snow peas, broccoli, cucumber, carrot, onion, sesame seeds, spicy asian vinaigrette",,,,,,,,,,F,10/06/2025
+Buffalo Ranch Potato Salad (1000  gram),Teraanga Commons Dining Hall,,140,,F,T,F,F,,"red potatoes, red pepper, celery, green onion, buffalo ranch dressing",,,,,,,,,,F,10/06/2025
+Carrot (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Creamy Chickpea Salad (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,"chickpeas, celery, green onion, red pepper, italian parsley, tahini lemon garlic vinaigrette",,,,,,,,,,F,10/06/2025
+Grainy Dijon Potato Salad (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,"mini red potatoes, mustard vinaigrette ",,,,,,,,,,F,10/06/2025
+Hoisin Chow Mein Salad (59  millilitre),Teraanga Commons Dining Hall,,40,,F,F,F,T,,"chow mein noodles, napa cabbage, cucumber, carrot, daikon radish, red peppers, green onion, sesame seeds, hoisin ginger vinaigrette",,,,,,,,,,F,10/06/2025
+Jalapeno Coleslaw (1000  gram),Teraanga Commons Dining Hall,,,,F,T,F,T,,"cabbage, carrot, jalapenos, creamy dressing",,,,,,,,,,F,10/06/2025
+Kale Apple Chickpea Salad (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,"chickpeas, cauliflower, carrot, kale, red onion, apple, fresh parsley, maple dijon vinaigrette",,,,,,,,,,F,10/06/2025
+Superfood Salad (1000  gram),Teraanga Commons Dining Hall,,,,F,F,F,T,,"chickpeas, couscous, tomato, cucumber, red onion, kale, feta cheese, greek vinaigrette",,,,,,,,,,F,10/06/2025
+Tomato Mozzarella Penne (1000  gram),Teraanga Commons Dining Hall,,,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Balsamic Glaze,Teraanga Commons Dining Hall,,35,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Quinoa,Teraanga Commons Dining Hall,,45,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Pork Souvlaki,Teraanga Commons Dining Hall,,190,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Deli Roast Beef,Teraanga Commons Dining Hall,,140,,F,F,F,F,,Roast Beef,,,,,,,,,,F,10/06/2025
+Edamame,Teraanga Commons Dining Hall,,60,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Falafel,Teraanga Commons Dining Hall,,210,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Korean Lentils,Teraanga Commons Dining Hall,,,,T,F,F,T,,,,,,,,,,,,F,10/06/2025
+Asian Tofu (59  millilitre),Teraanga Commons Dining Hall,,45,,T,F,F,T,,,,,,,,,,,,F,10/06/2025
+Chasu Pork Loin (1  slice),Teraanga Commons Dining Hall,,70,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Egg (118  millilitre),Teraanga Commons Dining Hall,,180,,F,T,F,T,,,,,,,,,,,,F,10/06/2025
+Egg White (118  millilitre),Teraanga Commons Dining Hall,,60,,F,T,F,T,,,,,,,,,,,,F,10/06/2025
+Five Spice Chicken (90  millilitre),Teraanga Commons Dining Hall,,180,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Ground Beef (1  kilogram),Teraanga Commons Dining Hall,,,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Ham (3  slice),Teraanga Commons Dining Hall,,60,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Ham (59  millilitre),Teraanga Commons Dining Hall,,30,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Hard Cooked Egg (1  piece),Teraanga Commons Dining Hall,,60,,F,T,F,T,,,,,,,,,,,,F,10/06/2025
+Tuna Salad (59  millilitre),Teraanga Commons Dining Hall,,90,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Tuna Salad (80  millilitre),Teraanga Commons Dining Hall,,100,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Pesto Sauce,Teraanga Commons Dining Hall,,420,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Creamy Scrambled Egg,Teraanga Commons Dining Hall,,170,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+French Toast,Teraanga Commons Dining Hall,,120,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Chicken Bruschetta Penne Alfredo,Teraanga Commons Dining Hall,,230,,F,F,F,F,,"chicken breast, tomato, basil, parmesan, alfredo sauce, penne",,,,,,,,,,F,10/06/2025
+Kale Squash Gnocchi,Teraanga Commons Dining Hall,,320,,T,F,F,T,,"butternut squash, kale, sage, gnocchi",,,,,,,,,,F,10/06/2025
+Farfalle,Teraanga Commons Dining Hall,,200,,T,F,F,T,,,,,,,,,,,,F,10/06/2025
+No Gluten Fusilli,Teraanga Commons Dining Hall,,210,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+No Gluten Penne,Teraanga Commons Dining Hall,,160,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Ramen Noodles,Teraanga Commons Dining Hall,,70,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Rice Noodles,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Rotini,Teraanga Commons Dining Hall,,200,,T,F,F,T,,,,,,,,,,,,F,10/06/2025
+Blueberry Tart,Teraanga Commons Dining Hall,,120,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Maple Butter Tart,Teraanga Commons Dining Hall,,130,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Hash Brown,Teraanga Commons Dining Hall,,60,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Home Fried Potatoes,Teraanga Commons Dining Hall,,180,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Home Style Potatoes,Teraanga Commons Dining Hall,,90,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Parsley Potatoes,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Potato Wedges,Teraanga Commons Dining Hall,,110,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Red Potatoes,Teraanga Commons Dining Hall,,120,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Red Potatoes & Onions,Teraanga Commons Dining Hall,,160,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Roasted Potatoes,Teraanga Commons Dining Hall,,130,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Beef Quesadilla,Teraanga Commons Dining Hall,,280,,F,F,F,F,,"taco-spiced ground beef, cheddar cheese, tortilla",,,,,,,,,,F,10/06/2025
+Caramel Coffee Cake,Teraanga Commons Dining Hall,,300,,F,F,F,F,,,,,,,,,,,,F,10/06/2025
+Dill Pickles,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Aromatic Basmati Rice,Teraanga Commons Dining Hall,,120,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Cajun-Style Dirty Rice,Teraanga Commons Dining Hall,,160,,T,T,F,T,,"black beans, onion, red pepper, celery, peas, spices, brown rice",,,,,,,,,,F,10/06/2025
+Coconut Jasmine Rice,Teraanga Commons Dining Hall,,190,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+White Rice,Teraanga Commons Dining Hall,,130,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Herb Roasted Chicken,Teraanga Commons Dining Hall,,170,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Baby Kale,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Black Olives,Teraanga Commons Dining Hall,,25,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Bok Choy,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Chickpeas,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Corn,Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Cucumber,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Dried Cranberries,Teraanga Commons Dining Hall,,25,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Garlic,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Green Onion,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Green Pepper,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Market Mixed Greens,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+MTO PTN SUNFLOWER SEEDS (30 ML),Teraanga Commons Dining Hall,,110,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Mushroom,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Nori Seaweed,Teraanga Commons Dining Hall,,10,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Onion,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Parmesan Cheese,Teraanga Commons Dining Hall,,10,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Pumpkin Seeds,Teraanga Commons Dining Hall,,80,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Red Onion,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Spring Mix,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Tofu,Teraanga Commons Dining Hall,,45,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Tomato,Teraanga Commons Dining Hall,,10,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Zucchini,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Lemon Garlic Vinaigrette,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Apple Cabbage Slaw,Teraanga Commons Dining Hall,,60,,F,T,F,T,,,,,,,,,,,,F,10/06/2025
+Chickpea & Root Vegetable Soup (8000  millilitre),Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Coconut Curry Chickpea Soup (474  millilitre),Teraanga Commons Dining Hall,,480,,T,T,F,T,,"Chickpeas, lentils and sweet potatoes simmered in coconut, ginger, turmeric and cinnamon flavours.",,,,,,,,,,F,10/06/2025
+Corn Lentil Soup (8000  millilitre),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Mediterranean Kale Minestrone Soup (8000  millilitre),Teraanga Commons Dining Hall,,,,T,T,F,T,,"A twist on a classic Italian vegetable broth soup containing brown rice, white beans and kale.",,,,,,,,,,F,10/06/2025
+Moroccan Chickpea Soup (237  millilitre),Teraanga Commons Dining Hall,,120,,T,T,F,T,,"A flavourful tomato-based broth soup loaded with chickpeas, potatoes, carrots, spinach and warm spices.",,,,,,,,,,F,10/06/2025
+No Gluten Turkey Noodle Soup (8  litre),Teraanga Commons Dining Hall,,,,F,T,F,F,,Home-style soup with pieces of turkey breast and no gluten fettuccine noodles.,,,,,,,,,,F,10/06/2025
+Hummus,Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Sour Cream,Teraanga Commons Dining Hall,,15,,F,T,F,T,,,,,,,,,,,,F,10/06/2025
+Bean Ragout,Teraanga Commons Dining Hall,,130,,T,T,F,T,,"kidney beans, chickpeas, onion, green pepper, carrot, tomato",,,,,,,,,,F,10/06/2025
+Cauliflower Bulgur Curry,Teraanga Commons Dining Hall,,160,,T,F,F,T,,"lentil, bulgur, cauliflower, red pepper, onion, coconut milk",,,,,,,,,,F,10/06/2025
+Chickpea Curry,Teraanga Commons Dining Hall,,150,,F,T,F,T,,,,,,,,,,,,F,10/06/2025
+Kung Pao Tofu,Teraanga Commons Dining Hall,,150,,T,F,F,T,,,,,,,,,,,,F,10/06/2025
+Marrakesh Vegetable Stew,Teraanga Commons Dining Hall,,120,,T,T,F,T,,"chickpeas, potato, zucchini, tomato, carrots",,,,,,,,,,F,10/06/2025
+Sadza Chicken Stew,Teraanga Commons Dining Hall,,160,,F,F,F,F,,"chicken, onion, tomato, green onion",,,,,,,,,,F,10/06/2025
+"STEW, GOULASH, BEEF, POTATO, VEGETABLES RES",Teraanga Commons Dining Hall,,100,,F,T,F,F,,,,,,,,,,,,F,10/06/2025
+Chili Garlic Veggie Stir Fry,Teraanga Commons Dining Hall,,90,,T,F,F,T,,"cabbage, carrot, celery, onion, spices, sweet chili sauce, soy sauce",,,,,,,,,,F,10/06/2025
+Thai Tofu Stir Fry,Teraanga Commons Dining Hall,,170,,T,T,F,T,,"tofu, onion, carrot, snow peas, green pepper, cabbage, sweet and spicy sauce, soy sauce, green onion",,,,,,,,,,F,10/06/2025
+Egg Salad Baguette,Teraanga Commons Dining Hall,,200,,F,F,F,T,,"egg salad, lettuce, baguette",,,,,,,,,,F,10/06/2025
+Meatball Sub,Teraanga Commons Dining Hall,,230,,F,F,F,F,,"meatballs, mozzarella, tomato basil sauce, pesto mayo",,,,,,,,,,F,10/06/2025
+Chicken Tinga Taco,Teraanga Commons Dining Hall,,240,,F,F,F,F,,"chicken tinga, lettuce, tomato, sour cream, cheddar cheese, tortilla",,,,,,,,,,F,10/06/2025
+Broccoli,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Green Beans,Teraanga Commons Dining Hall,,35,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Green Peas,Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Sauteed Zucchini,Teraanga Commons Dining Hall,,40,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Vegetable Medley,Teraanga Commons Dining Hall,,60,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Ginger Roasted Cauliflower & Carrots,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Roasted Corn & Green Pepper,Teraanga Commons Dining Hall,,120,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Roasted Eggplant,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Curried Carrots,Teraanga Commons Dining Hall,,80,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Roasted Beets & Basil,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,,F,10/06/2025
+Cauliflower Lentil Wrap,Teraanga Commons Dining Hall,,260,,T,F,F,T,,"cauliflower & red lentil curry, basmati rice, tortilla",,,,,,,,,,F,10/06/2025
+Chickpea Shawarma Wrap,Teraanga Commons Dining Hall,,240,,T,F,F,T,,"smashed lemon tahini chickpeas, pickled red cabbage, cucumber, carrots, lettuce, garlic sauce, tortilla",,,,,,,,,,F,10/06/2025
+Grilled Vegetable Wrap,Teraanga Commons Dining Hall,,200,,F,F,F,F,,"grilled zucchini, roasted red pepper, spinach, sundried tomato pesto, tortilla",,,,,,,,,,F,10/06/2025
+Korean BBQ Tempeh Wrap,Teraanga Commons Dining Hall,,280,,T,F,F,T,,"korean BBQ tempeh, red pepper, green onion, guacamole, lettuce, sesame seeds, tortilla",,,,,,,,,,F,10/06/2025
+Vegetable Provolone Wrap,Teraanga Commons Dining Hall,,260,,F,F,F,F,,"carrot, red onion, zucchini, bell pepper, lettuce, tomato, provolone cheese, basil  pesto mayo, tortilla",,,,,,,,,,F,10/06/2025
+Garlic Bread,Teraanga Commons Dining Hall,,170,,F,F,F,T,,,,,,,,,,,,F,10/06/2025
+Garlic Croutons,Teraanga Commons Dining Hall,,60,,T,F,F,T,,,,,,,,,,,,F,10/06/2025

--- a/backend/web-scraping/caf_scraper.py
+++ b/backend/web-scraping/caf_scraper.py
@@ -1,0 +1,91 @@
+import requests
+import csv
+import os
+
+# Date from which to fetch the weekly menu (MM/DD/YYYY)
+date = "10/06/2025"
+
+# URL to access the Caf's menu for the week of "date"
+url = "https://carleton.campusdish.com/api/menu/GetMenus?locationId=24967&storeIds=&mode=Weekly&date=" + date + "&time=&periodId=2084&fulfillmentMethod="
+
+# Fetch JSON data
+response = requests.get(url)
+data = response.json()
+
+# Construct the full path for the CSV
+script_dir = os.path.dirname(os.path.abspath(__file__))
+csv_file = os.path.join(script_dir, "cafFoodInfo.csv")
+
+# Headers for the CSV
+headers = [
+    "Food Item", "Dining Location", "Cost", "Calories", "Nuts", "Vegan",
+    "Gluten Free", "Halal", "Vegetarian", "No Dairy", "Comments",
+    "Eggs", "Fish", "Milk", "Peanuts", "Sesame", "Shellfish", "Soy",
+    "TreeNuts", "Wheat", "Kosher", "Last Updated"
+]
+
+# Helper to function convert boolean to 'T' / 'F'
+def bool_to_tf(value):
+    if value is True:
+        return "T"
+    elif value is False:
+        return "F"
+    return ""
+
+# Keep track of marketing names to avoid duplicates
+added_names = set()
+
+# Open CSV for writing
+with open(csv_file, mode='w', newline='', encoding='utf-8') as file:
+    writer = csv.DictWriter(file, fieldnames=headers)
+    writer.writeheader()
+
+    # Iterate over products in MenuProducts
+    for menu_product in data.get("Menu", {}).get("MenuProducts", []):
+        product = menu_product.get("Product", {})
+        marketing_name = product.get("MarketingName", "")
+
+        # Skip duplicates
+        if marketing_name in added_names:
+            continue
+        added_names.add(marketing_name)
+
+        # Extract dietary info
+        filters = product.get("AvailableFilters", {})
+
+        # Extract calories from NutritionalTree
+        calories = ""
+        for nutrient in product.get("NutritionalTree", []):
+            if nutrient.get("Name") == "Calories":
+                calories = nutrient.get("Value", "")
+                break
+
+        # Prepare CSV row
+        row = {
+            "Food Item": marketing_name,
+            "Dining Location": "Teraanga Commons Dining Hall",
+            "Cost": "",
+            "Calories": calories,
+            "Nuts": "",
+            "Vegan": bool_to_tf(filters.get("IsVegan")),
+            "Gluten Free": bool_to_tf(filters.get("IsGlutenFree")),
+            "Halal": bool_to_tf(filters.get("IsHalal")),
+            "Vegetarian": bool_to_tf(filters.get("IsVegetarian")),
+            "No Dairy": "",
+            "Comments": product.get("ShortDescription", ""),
+            "Eggs": bool_to_tf(filters.get("Eggs")),
+            "Fish": bool_to_tf(filters.get("Fish")),
+            "Milk": bool_to_tf(filters.get("Milk")),
+            "Peanuts": bool_to_tf(filters.get("Peanuts")),
+            "Sesame": bool_to_tf(filters.get("Sesame")),
+            "Shellfish": bool_to_tf(filters.get("Shellfish")),
+            "Soy": bool_to_tf(filters.get("Soy")),
+            "TreeNuts": bool_to_tf(filters.get("TreeNuts")),
+            "Wheat": bool_to_tf(filters.get("Wheat")),
+            "Kosher": bool_to_tf(filters.get("IsKosher")),
+            "Last Updated": date,
+        }
+
+        writer.writerow(row)
+
+print(f"Data exported successfully to {csv_file}.")

--- a/backend/web-scraping/caf_scraper.py
+++ b/backend/web-scraping/caf_scraper.py
@@ -6,7 +6,11 @@ import os
 date = "10/06/2025"
 
 # URL to access the Caf's menu for the week of "date"
-url = "https://carleton.campusdish.com/api/menu/GetMenus?locationId=24967&storeIds=&mode=Weekly&date=" + date + "&time=&periodId=2084&fulfillmentMethod="
+url = (
+    f"https://carleton.campusdish.com/api/menu/GetMenus?"
+    f"locationId=24967&storeIds=&mode=Weekly&date={date}"
+    f"&time=&periodId=2084&fulfillmentMethod="
+)
 
 # Fetch JSON data
 response = requests.get(url)
@@ -24,6 +28,7 @@ headers = [
     "TreeNuts", "Wheat", "Kosher", "Last Updated"
 ]
 
+
 # Helper to function convert boolean to 'T' / 'F'
 def bool_to_tf(value):
     if value is True:
@@ -31,6 +36,7 @@ def bool_to_tf(value):
     elif value is False:
         return "F"
     return ""
+
 
 # Keep track of marketing names to avoid duplicates
 added_names = set()


### PR DESCRIPTION
# Description

This PR adds a web scraper for the Teraanga Commons Dining Hall, informally known as the Caf.

Fixes # (issue)
- Create automated data collection for the Caf based on https://carleton.campusdish.com/LocationsAndMenus/TeraangaCommonsDiningHall

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [x] Manual tests
- [x] Linted/formatted

Steps to Test:
1. cd backend/web-scraping
2. python caf_scraper.py
3. Check cafFoodInfo.csv created in backend/web-scraping

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Future Changes
This feature is for data collection only and has not been integrated with any database yet. Further work on the automated data generation front will come (other sites, OCR), along with better web-scraping documentation.
