### PR TITLE
feat: add simple auto-release workflow for git tag versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Auto Release
+
+on:
+    push:
+        tags:
+            - 'v*'
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+            - name: Get tag name
+              id: tag
+              run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+              
+            - name: Create zip archive
+              run: |
+                zip -r cu-bytes-${{ steps.tag.outputs.TAG_NAME }}.zip . \
+                -x "*.git*" \
+                -x "*node_modules*" \
+                -x "*__pycache__*" \
+                -x "*.pyc" \
+                -x "*backenv/*" \
+                -x "*mlenv/*" \
+                -x "*.env" \
+                -x "*.venv" \
+                -x "*.pytest_cache*"
+            
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v1
+              with:
+                tag_name: ${{ steps.tag.outputs.TAG_NAME }}
+                name: ${{ steps.tag.outputs.TAG_NAME }}
+                body: |
+                    Release ${{ steps.tag.outputs.TAG_NAME }}
+                    
+                files: cu-bytes-${{ steps.tag.outputs.TAG_NAME }}.zip
+                draft: false
+                prerelease: false
+
+# How to create a release
+# git push origin vX.X.X


### PR DESCRIPTION
# Description

Adds an automated GitHub Actions workflow that creates [releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) and zip artifacts when git tags are pushed. This  creates downloadable zip archives of the repository for each release.

- Triggers automatically when tags matching `v*` pattern are pushed
- Creates a zip archive of the repository excluding build artifacts
- Creates a GitHub release with the zip file attached

I want us to have old versions of our work we could easily look back at, as I'll be making quite a few large changes in the next 2 days. If this PR is accepted I'll start us off on `v0.1.0`. 

Simply run `git push origin vMAJOR.MINOR.PATCH`:
MAJOR (v1.0.0 → v2.0.0): Breaking changes that aren't backwards compatible
MINOR (v1.0.0 → v1.1.0): New backwards-compatible features
PATCH (v1.0.0 → v1.0.1): Backwards-compatible bug fixes
(see [semantic versioning](https://semver.org/) for more information)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Manual tests
- [ ] Linted/formatted
- [x] Unfortunately no easy way to test workflows without running them first

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
