### PR TITLE
Feature/automation scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,5 @@ jobs:
                 prerelease: false
 
 # How to create a release
+# git tag vX.X.X
 # git push origin vX.X.X

--- a/machine-learning/TRAINING_GUIDE.md
+++ b/machine-learning/TRAINING_GUIDE.md
@@ -1,0 +1,300 @@
+# Food Recognition Model Training Guide
+
+This guide explains how to train the food recognition model using the automated training script.
+
+## Overview
+
+The food recognition model is a deep learning classifier that can identify different types of food from images. It uses transfer learning with pre-trained models (ResNet50, EfficientNet, or MobileNet) fine-tuned on food datasets.
+
+### What the Model Does
+
+- **Input**: Food images (JPG, PNG, etc.)
+- **Output**: Food category classification (e.g., "pizza", "burger", "sushi")
+- **Architecture**: Deep convolutional neural network based on pre-trained models
+- **Training**: Fine-tuned on food datasets (Food-101, UEC Food-100, UEC Food-256)
+
+The model is designed for the CU-Bytes food tracking application, where users can scan food items and automatically log nutritional information.
+
+## Prerequisites
+
+- **Python 3.8+** installed
+- **Git** (for cloning the repository)
+- **NVIDIA GPU** (optional, but highly recommended for faster training)
+  - CUDA 12.1 compatible GPU
+  - CUDA Toolkit installed (for GPU training)
+
+### Windows Users
+
+If you get a PowerShell execution policy error when running `train.ps1`, run this command first:
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
+Alternatively, you can use Git Bash or WSL to run the `train.sh` script instead.
+
+### System Requirements
+
+- **Minimum**: CPU-only training (very slow, not recommended)
+- **Recommended**: NVIDIA GPU with 4GB+ VRAM
+- **Optimal**: NVIDIA GPU with 8GB+ VRAM (RTX 3060, RTX 3070, etc.)
+
+## Quick Start
+
+### 1. Navigate to the Machine Learning Directory
+
+```bash
+cd machine-learning
+```
+
+### 2. Run the Training Script
+
+**On Linux/Mac (or Git Bash/WSL on Windows):**
+
+```bash
+./train.sh
+```
+
+**On Windows (PowerShell):**
+
+```powershell
+.\train.ps1
+```
+
+This will:
+- Create a Python virtual environment
+- Install all dependencies (including PyTorch with GPU/CPU detection)
+- Download configured datasets
+- Start training with default settings
+
+### 3. Monitor Training
+
+Training progress is logged to TensorBoard. In a separate terminal:
+
+```bash
+# Activate the virtual environment first
+source mlenv/bin/activate  # On Linux/Mac
+# or
+mlenv\Scripts\activate      # On Windows
+
+# Start TensorBoard
+tensorboard --logdir models/runs
+```
+
+Then open `http://localhost:6006` in your browser to view training metrics.
+
+## Training Script Options
+
+Both `train.sh` (Linux/Mac) and `train.ps1` (Windows) support the same options for customizing training:
+
+### Basic Options
+
+**Linux/Mac:**
+```bash
+# Custom batch size and epochs
+./train.sh --batch-size 16 --epochs 30
+
+# Use a different model architecture
+./train.sh --model efficientnet_b0
+
+# Adjust learning rate and image size
+./train.sh --lr 0.001 --image-size 256
+```
+
+**Windows:**
+```powershell
+# Custom batch size and epochs
+.\train.ps1 -BatchSize 16 -Epochs 30
+
+# Use a different model architecture
+.\train.ps1 -Model efficientnet_b0
+
+# Adjust learning rate and image size
+.\train.ps1 -LearningRate 0.001 -ImageSize 256
+```
+
+### Advanced Options
+
+**Linux/Mac:**
+```bash
+# Resume training from a checkpoint
+./train.sh --resume models/checkpoints/checkpoint_epoch_10.pth
+
+# Freeze backbone for fine-tuning (faster, less memory)
+./train.sh --freeze-backbone
+
+# Test GPU before training
+./train.sh --test-gpu
+
+# Use custom datasets config
+./train.sh --config custom_datasets_config.json
+
+# Skip setup (use existing environment)
+./train.sh --skip-setup
+
+# Skip dataset download (use existing datasets)
+./train.sh --skip-download
+```
+
+**Windows:**
+```powershell
+# Resume training from a checkpoint
+.\train.ps1 -Resume models\checkpoints\checkpoint_epoch_10.pth
+
+# Freeze backbone for fine-tuning
+.\train.ps1 -FreezeBackbone
+
+# Test GPU before training
+.\train.ps1 -TestGPU
+
+# Use custom datasets config
+.\train.ps1 -ConfigFile custom_datasets_config.json
+
+# Skip setup (use existing environment)
+.\train.ps1 -SkipSetup
+
+# Skip dataset download (use existing datasets)
+.\train.ps1 -SkipDownload
+```
+
+### All Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--model` | Model architecture (resnet50, efficientnet_b0, mobilenet_v3_small) | resnet50 |
+| `--batch-size` | Batch size for training | 32 |
+| `--epochs` | Number of training epochs | 50 |
+| `--lr` | Learning rate | 0.0001 |
+| `--image-size` | Image size for training | 224 |
+| `--resume` | Resume from checkpoint path | - |
+| `--freeze-backbone` | Freeze backbone layers | false |
+| `--test-gpu` | Test GPU setup before training | false |
+| `--config` | Path to datasets config file | datasets_config.json |
+| `--venv-name` | Virtual environment name | mlenv |
+| `--skip-setup` | Skip environment setup | false |
+| `--skip-download` | Skip dataset download | false |
+| `-h, --help` | Show help message | - |
+
+## Examples
+
+### Example 1: Quick Test Run
+
+Train for a few epochs to test the setup:
+
+**Linux/Mac:**
+```bash
+./train.sh --epochs 5 --batch-size 16
+```
+
+**Windows:**
+```powershell
+.\train.ps1 -Epochs 5 -BatchSize 16
+```
+
+### Example 2: GPU Training with EfficientNet
+
+Train EfficientNet model on GPU with optimized settings:
+
+**Linux/Mac:**
+```bash
+./train.sh --model efficientnet_b0 --batch-size 32 --epochs 50 --test-gpu
+```
+
+**Windows:**
+```powershell
+.\train.ps1 -Model efficientnet_b0 -BatchSize 32 -Epochs 50 -TestGPU
+```
+
+### Example 3: Resume Training
+
+Continue training from a checkpoint:
+
+**Linux/Mac:**
+```bash
+./train.sh --resume models/checkpoints/checkpoint_epoch_20.pth --epochs 50
+```
+
+**Windows:**
+```powershell
+.\train.ps1 -Resume models\checkpoints\checkpoint_epoch_20.pth -Epochs 50
+```
+
+### Example 4: Low Memory Training
+
+If you have limited GPU memory:
+
+**Linux/Mac:**
+```bash
+./train.sh --batch-size 8 --image-size 128 --freeze-backbone
+```
+
+**Windows:**
+```powershell
+.\train.ps1 -BatchSize 8 -ImageSize 128 -FreezeBackbone
+```
+
+### Example 5: CPU Training
+
+Train on CPU (much slower):
+
+**Linux/Mac:**
+```bash
+./train.sh --batch-size 4 --epochs 10
+```
+
+**Windows:**
+```powershell
+.\train.ps1 -BatchSize 4 -Epochs 10
+```
+
+Note: The script automatically detects CPU/GPU and installs the appropriate PyTorch version.
+
+## Dataset Configuration
+
+Datasets are configured in `datasets_config.json`. By default, the following datasets are enabled:
+
+- **Food-101**: 101 food categories (primary dataset)
+
+To customize datasets:
+
+1. Edit `datasets_config.json`
+2. Set `"enabled": false` for datasets you don't want to use
+3. Add new datasets following the existing format
+
+## Training Output
+
+After training completes, you'll find:
+
+- **Checkpoints**: `models/checkpoints/checkpoint_epoch_*.pth`
+  - Saved after each epoch
+  - Contains model weights, optimizer state, and training metrics
+
+- **Best Model**: `models/best_model.pth`
+  - Model with highest validation accuracy
+  - Use this for inference/deployment
+
+- **Class Names**: `models/class_names.json`
+  - List of all food categories the model can recognize
+
+- **TensorBoard Logs**: `models/runs/`
+  - Training/validation loss and accuracy over time
+  - View with: `tensorboard --logdir models/runs`
+
+## Troubleshooting
+
+### GPU Not Detected
+
+If GPU is not detected:
+
+1. Check NVIDIA drivers are installed: `nvidia-smi`
+2. Verify CUDA is installed: `nvcc --version`
+3. The script will automatically fall back to CPU training
+
+### Out of Memory Errors
+
+If you get CUDA out of memory errors:
+
+- Reduce batch size: `--batch-size 8` or `--batch-size 4`
+- Reduce image size: `--image-size 128`
+- Use freeze backbone: `--freeze-backbone`
+- Use a smaller model: `--model mobilenet_v3_small`

--- a/machine-learning/TRAINING_GUIDE.md
+++ b/machine-learning/TRAINING_GUIDE.md
@@ -62,6 +62,7 @@ cd machine-learning
 ```
 
 This will:
+
 - Create a Python virtual environment
 - Install all dependencies (including PyTorch with GPU/CPU detection)
 - Download configured datasets
@@ -90,6 +91,7 @@ Both `train.sh` (Linux/Mac) and `train.ps1` (Windows) support the same options f
 ### Basic Options
 
 **Linux/Mac:**
+
 ```bash
 # Custom batch size and epochs
 ./train.sh --batch-size 16 --epochs 30
@@ -102,6 +104,7 @@ Both `train.sh` (Linux/Mac) and `train.ps1` (Windows) support the same options f
 ```
 
 **Windows:**
+
 ```powershell
 # Custom batch size and epochs
 .\train.ps1 -BatchSize 16 -Epochs 30
@@ -116,6 +119,7 @@ Both `train.sh` (Linux/Mac) and `train.ps1` (Windows) support the same options f
 ### Advanced Options
 
 **Linux/Mac:**
+
 ```bash
 # Resume training from a checkpoint
 ./train.sh --resume models/checkpoints/checkpoint_epoch_10.pth
@@ -137,6 +141,7 @@ Both `train.sh` (Linux/Mac) and `train.ps1` (Windows) support the same options f
 ```
 
 **Windows:**
+
 ```powershell
 # Resume training from a checkpoint
 .\train.ps1 -Resume models\checkpoints\checkpoint_epoch_10.pth
@@ -159,21 +164,21 @@ Both `train.sh` (Linux/Mac) and `train.ps1` (Windows) support the same options f
 
 ### All Options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--model` | Model architecture (resnet50, efficientnet_b0, mobilenet_v3_small) | resnet50 |
-| `--batch-size` | Batch size for training | 32 |
-| `--epochs` | Number of training epochs | 50 |
-| `--lr` | Learning rate | 0.0001 |
-| `--image-size` | Image size for training | 224 |
-| `--resume` | Resume from checkpoint path | - |
-| `--freeze-backbone` | Freeze backbone layers | false |
-| `--test-gpu` | Test GPU setup before training | false |
-| `--config` | Path to datasets config file | datasets_config.json |
-| `--venv-name` | Virtual environment name | mlenv |
-| `--skip-setup` | Skip environment setup | false |
-| `--skip-download` | Skip dataset download | false |
-| `-h, --help` | Show help message | - |
+| Option              | Description                                                        | Default              |
+| ------------------- | ------------------------------------------------------------------ | -------------------- |
+| `--model`           | Model architecture (resnet50, efficientnet_b0, mobilenet_v3_small) | resnet50             |
+| `--batch-size`      | Batch size for training                                            | 32                   |
+| `--epochs`          | Number of training epochs                                          | 50                   |
+| `--lr`              | Learning rate                                                      | 0.0001               |
+| `--image-size`      | Image size for training                                            | 224                  |
+| `--resume`          | Resume from checkpoint path                                        | -                    |
+| `--freeze-backbone` | Freeze backbone layers                                             | false                |
+| `--test-gpu`        | Test GPU setup before training                                     | false                |
+| `--config`          | Path to datasets config file                                       | datasets_config.json |
+| `--venv-name`       | Virtual environment name                                           | mlenv                |
+| `--skip-setup`      | Skip environment setup                                             | false                |
+| `--skip-download`   | Skip dataset download                                              | false                |
+| `-h, --help`        | Show help message                                                  | -                    |
 
 ## Examples
 
@@ -182,11 +187,13 @@ Both `train.sh` (Linux/Mac) and `train.ps1` (Windows) support the same options f
 Train for a few epochs to test the setup:
 
 **Linux/Mac:**
+
 ```bash
 ./train.sh --epochs 5 --batch-size 16
 ```
 
 **Windows:**
+
 ```powershell
 .\train.ps1 -Epochs 5 -BatchSize 16
 ```
@@ -196,11 +203,13 @@ Train for a few epochs to test the setup:
 Train EfficientNet model on GPU with optimized settings:
 
 **Linux/Mac:**
+
 ```bash
 ./train.sh --model efficientnet_b0 --batch-size 32 --epochs 50 --test-gpu
 ```
 
 **Windows:**
+
 ```powershell
 .\train.ps1 -Model efficientnet_b0 -BatchSize 32 -Epochs 50 -TestGPU
 ```
@@ -210,11 +219,13 @@ Train EfficientNet model on GPU with optimized settings:
 Continue training from a checkpoint:
 
 **Linux/Mac:**
+
 ```bash
 ./train.sh --resume models/checkpoints/checkpoint_epoch_20.pth --epochs 50
 ```
 
 **Windows:**
+
 ```powershell
 .\train.ps1 -Resume models\checkpoints\checkpoint_epoch_20.pth -Epochs 50
 ```
@@ -224,11 +235,13 @@ Continue training from a checkpoint:
 If you have limited GPU memory:
 
 **Linux/Mac:**
+
 ```bash
 ./train.sh --batch-size 8 --image-size 128 --freeze-backbone
 ```
 
 **Windows:**
+
 ```powershell
 .\train.ps1 -BatchSize 8 -ImageSize 128 -FreezeBackbone
 ```
@@ -238,11 +251,13 @@ If you have limited GPU memory:
 Train on CPU (much slower):
 
 **Linux/Mac:**
+
 ```bash
 ./train.sh --batch-size 4 --epochs 10
 ```
 
 **Windows:**
+
 ```powershell
 .\train.ps1 -BatchSize 4 -Epochs 10
 ```
@@ -266,14 +281,17 @@ To customize datasets:
 After training completes, you'll find:
 
 - **Checkpoints**: `models/checkpoints/checkpoint_epoch_*.pth`
+
   - Saved after each epoch
   - Contains model weights, optimizer state, and training metrics
 
 - **Best Model**: `models/best_model.pth`
+
   - Model with highest validation accuracy
   - Use this for inference/deployment
 
 - **Class Names**: `models/class_names.json`
+
   - List of all food categories the model can recognize
 
 - **TensorBoard Logs**: `models/runs/`

--- a/machine-learning/train.ps1
+++ b/machine-learning/train.ps1
@@ -1,0 +1,188 @@
+# Food Recognition ML Pipeline - Automated Training Script (PowerShell)
+# This script automates the complete ML pipeline: environment setup, dataset download, and training
+
+param(
+    [string]$Model = "resnet50",
+    [int]$BatchSize = 32,
+    [int]$Epochs = 50,
+    [double]$LearningRate = 0.0001,
+    [int]$ImageSize = 224,
+    [string]$Resume = "",
+    [switch]$FreezeBackbone = $false,
+    [switch]$TestGPU = $false,
+    [string]$ConfigFile = "datasets_config.json",
+    [string]$VenvName = "mlenv",
+    [switch]$SkipSetup = $false,
+    [switch]$SkipDownload = $false,
+    [switch]$Help = $false
+)
+
+# Get script directory
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $ScriptDir
+
+# Show help
+if ($Help) {
+    Write-Host "Usage: .\train.ps1 [OPTIONS]"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -Model MODEL           Model architecture (resnet50, efficientnet_b0, mobilenet_v3_small) [default: resnet50]"
+    Write-Host "  -BatchSize SIZE        Batch size [default: 32]"
+    Write-Host "  -Epochs NUM            Number of training epochs [default: 50]"
+    Write-Host "  -LearningRate RATE     Learning rate [default: 0.0001]"
+    Write-Host "  -ImageSize SIZE        Image size for training [default: 224]"
+    Write-Host "  -Resume PATH           Resume training from checkpoint"
+    Write-Host "  -FreezeBackbone        Freeze backbone for fine-tuning"
+    Write-Host "  -TestGPU               Test GPU setup before training"
+    Write-Host "  -ConfigFile PATH       Path to datasets config file [default: datasets_config.json]"
+    Write-Host "  -VenvName NAME         Virtual environment name [default: mlenv]"
+    Write-Host "  -SkipSetup             Skip environment setup (use existing venv)"
+    Write-Host "  -SkipDownload          Skip dataset download (use existing datasets)"
+    Write-Host "  -Help                  Show this help message"
+    Write-Host ""
+    Write-Host "Examples:"
+    Write-Host "  .\train.ps1                                    # Full pipeline with defaults"
+    Write-Host "  .\train.ps1 -BatchSize 16 -Epochs 30         # Custom batch size and epochs"
+    Write-Host "  .\train.ps1 -Model efficientnet_b0            # Use EfficientNet model"
+    Write-Host "  .\train.ps1 -Resume models\checkpoints\...    # Resume from checkpoint"
+    exit 0
+}
+
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Food Recognition ML Pipeline" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Step 1: Setup Python Virtual Environment
+if (-not $SkipSetup) {
+    Write-Host "[1/4] Setting up Python virtual environment..." -ForegroundColor Yellow
+    
+    $VenvPath = Join-Path $ScriptDir $VenvName
+    
+    if (-not (Test-Path $VenvPath)) {
+        Write-Host "Creating virtual environment: $VenvName" -ForegroundColor Green
+        python -m venv $VenvName
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Error: Failed to create virtual environment" -ForegroundColor Red
+            exit 1
+        }
+    } else {
+        Write-Host "Virtual environment already exists: $VenvName" -ForegroundColor Green
+    }
+    
+    # Activate virtual environment
+    Write-Host "Activating virtual environment..." -ForegroundColor Green
+    & "$VenvPath\Scripts\Activate.ps1"
+    
+    # Upgrade pip
+    Write-Host "Upgrading pip..." -ForegroundColor Green
+    python -m pip install --upgrade pip --quiet
+    
+    # Install PyTorch (with GPU/CPU detection)
+    Write-Host "Detecting hardware for PyTorch installation..." -ForegroundColor Green
+    $hasGPU = $false
+    try {
+        $null = nvidia-smi 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $hasGPU = $true
+        }
+    } catch {
+        $hasGPU = $false
+    }
+    
+    if ($hasGPU) {
+        Write-Host "NVIDIA GPU detected. Installing PyTorch with CUDA support..." -ForegroundColor Green
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121 --quiet
+    } else {
+        Write-Host "No NVIDIA GPU detected. Installing PyTorch CPU version..." -ForegroundColor Yellow
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --quiet
+    }
+    
+    # Install other requirements
+    Write-Host "Installing Python dependencies..." -ForegroundColor Green
+    pip install -r requirements.txt --quiet
+    
+    Write-Host "Environment setup complete!" -ForegroundColor Green
+    Write-Host ""
+} else {
+    Write-Host "[1/4] Skipping environment setup..." -ForegroundColor Yellow
+    # Still activate existing venv
+    $VenvPath = Join-Path $ScriptDir $VenvName
+    & "$VenvPath\Scripts\Activate.ps1"
+    Write-Host ""
+}
+
+# Step 2: Download Datasets
+if (-not $SkipDownload) {
+    Write-Host "[2/4] Downloading datasets..." -ForegroundColor Yellow
+    
+    $ConfigPath = Join-Path $ScriptDir $ConfigFile
+    if (-not (Test-Path $ConfigPath)) {
+        Write-Host "Error: Config file not found: $ConfigPath" -ForegroundColor Red
+        exit 1
+    }
+    
+    python setup.py --setup --config $ConfigPath
+    
+    Write-Host "Dataset download complete!" -ForegroundColor Green
+    Write-Host ""
+} else {
+    Write-Host "[2/4] Skipping dataset download..." -ForegroundColor Yellow
+    Write-Host ""
+}
+
+# Step 3: Test GPU (optional)
+if ($TestGPU) {
+    Write-Host "[3/4] Testing GPU setup..." -ForegroundColor Yellow
+    python setup.py --test-gpu
+    Write-Host ""
+}
+
+# Step 4: Start Training
+Write-Host "[4/4] Starting training..." -ForegroundColor Yellow
+Write-Host "Configuration:" -ForegroundColor Green
+Write-Host "  Model: $Model"
+Write-Host "  Batch Size: $BatchSize"
+Write-Host "  Epochs: $Epochs"
+Write-Host "  Learning Rate: $LearningRate"
+Write-Host "  Image Size: $ImageSize"
+if ($Resume) {
+    Write-Host "  Resuming from: $Resume"
+}
+if ($FreezeBackbone) {
+    Write-Host "  Freeze Backbone: Yes"
+}
+Write-Host ""
+
+# Build training command
+$TrainCmd = "python train.py --model $Model --batch-size $BatchSize --epochs $Epochs --lr $LearningRate --image-size $ImageSize --datasets-config $ConfigFile"
+
+if ($Resume) {
+    $TrainCmd += " --resume $Resume"
+}
+
+if ($FreezeBackbone) {
+    $TrainCmd += " --freeze-backbone"
+}
+
+if ($TestGPU) {
+    $TrainCmd += " --test-gpu"
+}
+
+# Run training
+Write-Host "Starting training..." -ForegroundColor Green
+Write-Host ""
+Invoke-Expression $TrainCmd
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "Training pipeline completed!" -ForegroundColor Green
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Checkpoints saved to: models\checkpoints\" -ForegroundColor Green
+Write-Host "Best model saved to: models\best_model.pth" -ForegroundColor Green
+Write-Host "TensorBoard logs: models\runs\" -ForegroundColor Green
+Write-Host ""
+Write-Host "To view training progress, run:"
+Write-Host "  tensorboard --logdir models\runs" -ForegroundColor Green
+Write-Host ""

--- a/machine-learning/train.sh
+++ b/machine-learning/train.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# Food Recognition ML Pipeline - Automated Training Script
+# This script automates the complete ML pipeline: environment setup, dataset download, and training
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get script directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+# Default values
+VENV_NAME="mlenv"
+MODEL="resnet50"
+BATCH_SIZE=32
+EPOCHS=50
+LEARNING_RATE=0.0001
+IMAGE_SIZE=224
+RESUME=""
+FREEZE_BACKBONE=false
+TEST_GPU=false
+CONFIG_FILE="datasets_config.json"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        --batch-size)
+            BATCH_SIZE="$2"
+            shift 2
+            ;;
+        --epochs)
+            EPOCHS="$2"
+            shift 2
+            ;;
+        --lr)
+            LEARNING_RATE="$2"
+            shift 2
+            ;;
+        --image-size)
+            IMAGE_SIZE="$2"
+            shift 2
+            ;;
+        --resume)
+            RESUME="$2"
+            shift 2
+            ;;
+        --freeze-backbone)
+            FREEZE_BACKBONE=true
+            shift
+            ;;
+        --test-gpu)
+            TEST_GPU=true
+            shift
+            ;;
+        --config)
+            CONFIG_FILE="$2"
+            shift 2
+            ;;
+        --venv-name)
+            VENV_NAME="$2"
+            shift 2
+            ;;
+        --skip-setup)
+            SKIP_SETUP=true
+            shift
+            ;;
+        --skip-download)
+            SKIP_DOWNLOAD=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --model MODEL           Model architecture (resnet50, efficientnet_b0, mobilenet_v3_small) [default: resnet50]"
+            echo "  --batch-size SIZE       Batch size [default: 32]"
+            echo "  --epochs NUM            Number of training epochs [default: 50]"
+            echo "  --lr RATE               Learning rate [default: 0.0001]"
+            echo "  --image-size SIZE       Image size for training [default: 224]"
+            echo "  --resume PATH           Resume training from checkpoint"
+            echo "  --freeze-backbone       Freeze backbone for fine-tuning"
+            echo "  --test-gpu              Test GPU setup before training"
+            echo "  --config PATH           Path to datasets config file [default: datasets_config.json]"
+            echo "  --venv-name NAME        Virtual environment name [default: mlenv]"
+            echo "  --skip-setup            Skip environment setup (use existing venv)"
+            echo "  --skip-download         Skip dataset download (use existing datasets)"
+            echo "  -h, --help              Show this help message"
+            echo ""
+            echo "Examples:"
+            echo "  $0                                    # Full pipeline with defaults"
+            echo "  $0 --batch-size 16 --epochs 30       # Custom batch size and epochs"
+            echo "  $0 --model efficientnet_b0            # Use EfficientNet model"
+            echo "  $0 --resume models/checkpoints/...    # Resume from checkpoint"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Food Recognition ML Pipeline${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Step 1: Setup Python Virtual Environment
+if [ "$SKIP_SETUP" != true ]; then
+    echo -e "${YELLOW}[1/4] Setting up Python virtual environment...${NC}"
+    
+    if [ ! -d "$VENV_NAME" ]; then
+        echo -e "${GREEN}Creating virtual environment: $VENV_NAME${NC}"
+        python3 -m venv "$VENV_NAME" || python -m venv "$VENV_NAME"
+    else
+        echo -e "${GREEN}Virtual environment already exists: $VENV_NAME${NC}"
+    fi
+    
+    # Activate virtual environment
+    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == "cygwin" ]]; then
+        source "$VENV_NAME/Scripts/activate"
+    else
+        source "$VENV_NAME/bin/activate"
+    fi
+    
+    echo -e "${GREEN}Virtual environment activated${NC}"
+    
+    # Upgrade pip
+    echo -e "${GREEN}Upgrading pip...${NC}"
+    pip install --upgrade pip --quiet
+    
+    # Install PyTorch (with GPU/CPU detection)
+    echo -e "${GREEN}Detecting hardware for PyTorch installation...${NC}"
+    if command -v nvidia-smi &> /dev/null; then
+        echo -e "${GREEN}NVIDIA GPU detected. Installing PyTorch with CUDA support...${NC}"
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121 --quiet
+    else
+        echo -e "${YELLOW}No NVIDIA GPU detected. Installing PyTorch CPU version...${NC}"
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --quiet
+    fi
+    
+    # Install other requirements
+    echo -e "${GREEN}Installing Python dependencies...${NC}"
+    pip install -r requirements.txt --quiet
+    
+    echo -e "${GREEN}Environment setup complete!${NC}"
+    echo ""
+else
+    echo -e "${YELLOW}[1/4] Skipping environment setup...${NC}"
+    # Still activate existing venv
+    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == "cygwin" ]]; then
+        source "$VENV_NAME/Scripts/activate"
+    else
+        source "$VENV_NAME/bin/activate"
+    fi
+    echo ""
+fi
+
+# Step 2: Download Datasets
+if [ "$SKIP_DOWNLOAD" != true ]; then
+    echo -e "${YELLOW}[2/4] Downloading datasets...${NC}"
+    
+    CONFIG_PATH="$SCRIPT_DIR/$CONFIG_FILE"
+    if [ ! -f "$CONFIG_PATH" ]; then
+        echo -e "${RED}Error: Config file not found: $CONFIG_PATH${NC}"
+        exit 1
+    fi
+    
+    python setup.py --setup --config "$CONFIG_PATH"
+    
+    echo -e "${GREEN}Dataset download complete!${NC}"
+    echo ""
+else
+    echo -e "${YELLOW}[2/4] Skipping dataset download...${NC}"
+    echo ""
+fi
+
+# Step 3: Test GPU (optional)
+if [ "$TEST_GPU" = true ]; then
+    echo -e "${YELLOW}[3/4] Testing GPU setup...${NC}"
+    python setup.py --test-gpu
+    echo ""
+fi
+
+# Step 4: Start Training
+echo -e "${YELLOW}[4/4] Starting training...${NC}"
+echo -e "${GREEN}Configuration:${NC}"
+echo -e "  Model: $MODEL"
+echo -e "  Batch Size: $BATCH_SIZE"
+echo -e "  Epochs: $EPOCHS"
+echo -e "  Learning Rate: $LEARNING_RATE"
+echo -e "  Image Size: $IMAGE_SIZE"
+[ -n "$RESUME" ] && echo -e "  Resuming from: $RESUME"
+[ "$FREEZE_BACKBONE" = true ] && echo -e "  Freeze Backbone: Yes"
+echo ""
+
+# Build training command
+TRAIN_CMD="python train.py --model $MODEL --batch-size $BATCH_SIZE --epochs $EPOCHS --lr $LEARNING_RATE --image-size $IMAGE_SIZE --datasets-config $CONFIG_FILE"
+
+if [ -n "$RESUME" ]; then
+    TRAIN_CMD="$TRAIN_CMD --resume $RESUME"
+fi
+
+if [ "$FREEZE_BACKBONE" = true ]; then
+    TRAIN_CMD="$TRAIN_CMD --freeze-backbone"
+fi
+
+if [ "$TEST_GPU" = true ]; then
+    TRAIN_CMD="$TRAIN_CMD --test-gpu"
+fi
+
+# Run training
+echo -e "${GREEN}Starting training...${NC}"
+echo ""
+eval $TRAIN_CMD
+
+echo ""
+echo -e "${BLUE}========================================${NC}"
+echo -e "${GREEN}Training pipeline completed!${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+echo -e "Checkpoints saved to: ${GREEN}models/checkpoints/${NC}"
+echo -e "Best model saved to: ${GREEN}models/best_model.pth${NC}"
+echo -e "TensorBoard logs: ${GREEN}models/runs/${NC}"
+echo ""
+echo -e "To view training progress, run:"
+echo -e "  ${GREEN}tensorboard --logdir models/runs${NC}"
+echo ""

--- a/start-dev.bat
+++ b/start-dev.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Simple batch file wrapper for the PowerShell script
+powershell -ExecutionPolicy Bypass -File "%~dp0start-dev.ps1"

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -1,0 +1,194 @@
+# Development Startup Script for Cu-Bytes
+# This script:
+# 1. Sets up/activates Python virtual environment
+# 2. Initializes all databases
+# 3. Starts Flask backend server
+# 4. Installs frontend dependencies and starts Expo
+
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host "Starting Cu-Bytes Development Environment" -ForegroundColor Cyan
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Get the project root directory
+$projectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $projectRoot
+
+# Step 1: Setup Python Virtual Environment
+Write-Host "[1/6] Setting up Python virtual environment..." -ForegroundColor Yellow
+$venvPath = Join-Path $projectRoot "backend\backenv"
+
+if (-not (Test-Path $venvPath)) {
+    Write-Host "Creating virtual environment..." -ForegroundColor Green
+    $backendPath = Join-Path $projectRoot "backend"
+    Set-Location $backendPath
+    python -m venv backenv
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: Failed to create virtual environment. Make sure Python is installed." -ForegroundColor Red
+        exit 1
+    }
+    Set-Location $projectRoot
+}
+
+# Activate virtual environment
+Write-Host "Activating virtual environment..." -ForegroundColor Green
+& "$venvPath\Scripts\Activate.ps1"
+
+# Verify activation by checking Python path
+$pythonPath = (Get-Command python -ErrorAction SilentlyContinue).Source
+if ($pythonPath -and $pythonPath -like "*backenv*") {
+    Write-Host "Virtual environment activated successfully." -ForegroundColor Green
+} else {
+    Write-Host "Warning: Virtual environment may not be activated properly. Continuing anyway..." -ForegroundColor Yellow
+}
+
+# Install/upgrade pip and install requirements
+Write-Host "Installing Python dependencies..." -ForegroundColor Green
+python -m pip install --upgrade pip
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to upgrade pip. Make sure Python is installed and accessible." -ForegroundColor Red
+    exit 1
+}
+
+pip install -r backend\requirements.txt
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Failed to install Python requirements." -ForegroundColor Red
+    exit 1
+}
+
+# Step 2: Initialize Databases
+Write-Host ""
+Write-Host "[2/6] Initializing databases..." -ForegroundColor Yellow
+Write-Host "Note: Initializing in correct order (profiles must be created before auth users)" -ForegroundColor Gray
+Write-Host ""
+
+$dbPath = Join-Path $projectRoot "backend\database"
+$profilesDb = Join-Path $dbPath "profiles.db"
+$authDb = Join-Path $dbPath "auth.db"
+$foodDb = Join-Path $dbPath "food_data.db"
+$loggingDb = Join-Path $dbPath "logging.db"
+
+# Check if all databases exist
+$allDbsExist = (Test-Path $profilesDb) -and (Test-Path $authDb) -and (Test-Path $foodDb) -and (Test-Path $loggingDb)
+
+if ($allDbsExist) {
+    Write-Host "All databases already exist. Skipping initialization." -ForegroundColor Green
+    Write-Host "To reinitialize, delete the .db files in backend\database\ and run this script again." -ForegroundColor Gray
+} else {
+    Write-Host "Some databases are missing. Initializing..." -ForegroundColor Yellow
+    Write-Host ""
+
+    if (-not (Test-Path $profilesDb)) {
+        Write-Host "Initializing user settings database (profiles)..." -ForegroundColor Green
+        python -m backend.database.init_user_settings_db
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Warning: Failed to initialize user settings database." -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "User settings database (profiles) already exists. Skipping." -ForegroundColor Gray
+    }
+
+    if (-not (Test-Path $authDb)) {
+        Write-Host "Initializing auth database..." -ForegroundColor Green
+        python -m backend.database.init_auth_db
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Warning: Failed to initialize auth database." -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "Auth database already exists. Skipping." -ForegroundColor Gray
+    }
+
+    if (-not (Test-Path $foodDb)) {
+        Write-Host "Initializing food database..." -ForegroundColor Green
+        python -m backend.database.init_food_db
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Warning: Failed to initialize food database." -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "Food database already exists. Skipping." -ForegroundColor Gray
+    }
+
+    if (-not (Test-Path $loggingDb)) {
+        Write-Host "Initializing logging database..." -ForegroundColor Green
+        python -m backend.database.init_logging_db
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Warning: Failed to initialize logging database." -ForegroundColor Yellow
+        }
+    } else {
+        Write-Host "Logging database already exists. Skipping." -ForegroundColor Gray
+    }
+}
+
+# Step 3: Start Flask Backend Server
+Write-Host ""
+Write-Host "[3/6] Starting Flask backend server..." -ForegroundColor Yellow
+Write-Host "Flask server will run in background on http://127.0.0.1:5000" -ForegroundColor Green
+
+# Start Flask in a new PowerShell window
+$flaskScript = @"
+cd '$projectRoot'
+& '$venvPath\Scripts\Activate.ps1'
+python -m backend.app
+pause
+"@
+
+$flaskScript | Out-File -FilePath "$env:TEMP\start_flask.ps1" -Encoding UTF8
+Start-Process powershell -ArgumentList "-NoExit", "-File", "$env:TEMP\start_flask.ps1"
+
+# Wait a moment for Flask to start
+Start-Sleep -Seconds 3
+
+# Step 4: Setup Frontend Dependencies
+Write-Host ""
+Write-Host "[4/6] Installing frontend dependencies..." -ForegroundColor Yellow
+$frontendPath = Join-Path $projectRoot "frontend\cu-bytes"
+Set-Location $frontendPath
+
+if (-not (Test-Path "node_modules")) {
+    Write-Host "Running npm install..." -ForegroundColor Green
+    npm install
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: Failed to install frontend dependencies." -ForegroundColor Red
+        exit 1
+    }
+} else {
+    Write-Host "node_modules already exists. Skipping npm install." -ForegroundColor Green
+    Write-Host "Run 'npm install' manually if you need to update dependencies." -ForegroundColor Gray
+}
+
+# Step 5: Start Frontend (Expo)
+Write-Host ""
+Write-Host "[5/6] Starting Expo development server..." -ForegroundColor Yellow
+Write-Host "Expo will open in a new window/tab." -ForegroundColor Green
+
+# Start Expo in a new PowerShell window
+$expoScript = @"
+cd '$frontendPath'
+npm start
+pause
+"@
+
+$expoScript | Out-File -FilePath "$env:TEMP\start_expo.ps1" -Encoding UTF8
+Start-Process powershell -ArgumentList "-NoExit", "-File", "$env:TEMP\start_expo.ps1"
+
+# Step 6: Open Browser
+Write-Host ""
+Write-Host "[6/6] Opening browser..." -ForegroundColor Yellow
+Start-Sleep -Seconds 2
+
+# Open Flask API health check
+Start-Process "http://127.0.0.1:5000/api/health"
+
+Write-Host ""
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host "Setup Complete!" -ForegroundColor Green
+Write-Host "======================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Backend API: http://127.0.0.1:5000" -ForegroundColor Cyan
+Write-Host "API Health: http://127.0.0.1:5000/api/health" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Expo development server should open automatically." -ForegroundColor Cyan
+Write-Host "Check the PowerShell windows for Flask and Expo logs." -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Press any key to exit this script (servers will continue running)..." -ForegroundColor Gray
+$null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -14,6 +14,55 @@ Write-Host ""
 $projectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location $projectRoot
 
+function Wait-ForHttp {
+    param(
+        [Parameter(Mandatory=$true)][string]$Url,
+        [int]$TimeoutSeconds = 60,
+        [int]$DelayMs = 500
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 3
+            if ($resp.StatusCode -ge 200 -and $resp.StatusCode -lt 500) {
+                return $true
+            }
+        } catch {
+            # ignore until ready
+        }
+        Start-Sleep -Milliseconds $DelayMs
+    }
+    return $false
+}
+
+function Wait-ForTcpPort {
+    param(
+        [Parameter(Mandatory=$true)][string]$HostName,
+        [Parameter(Mandatory=$true)][int]$Port,
+        [int]$TimeoutSeconds = 60,
+        [int]$DelayMs = 500
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $client = New-Object System.Net.Sockets.TcpClient
+            $iar = $client.BeginConnect($HostName, $Port, $null, $null)
+            $connected = $iar.AsyncWaitHandle.WaitOne(3000, $false)
+            if ($connected -and $client.Connected) {
+                $client.Close()
+                return $true
+            }
+            $client.Close()
+        } catch {
+            # ignore until ready
+        }
+        Start-Sleep -Milliseconds $DelayMs
+    }
+    return $false
+}
+
 # Step 1: Setup Python Virtual Environment
 Write-Host "[1/6] Setting up Python virtual environment..." -ForegroundColor Yellow
 $venvPath = Join-Path $projectRoot "backend\backenv"
@@ -171,24 +220,34 @@ pause
 $expoScript | Out-File -FilePath "$env:TEMP\start_expo.ps1" -Encoding UTF8
 Start-Process powershell -ArgumentList "-NoExit", "-File", "$env:TEMP\start_expo.ps1"
 
-# Step 6: Open Browser
+# Step 6: Open Browser (only after servers are ready)
 Write-Host ""
-Write-Host "[6/6] Opening browser..." -ForegroundColor Yellow
-Start-Sleep -Seconds 2
+Write-Host "[6/6] Waiting for servers to be ready..." -ForegroundColor Yellow
 
-# Open Flask API health check
-Start-Process "http://127.0.0.1:5000/api/health"
+# 1) Wait for Flask
+# Prefer a dedicated health endpoint if you have one (recommended).
+# Example: http://127.0.0.1:5000/health
+$flaskReady = Wait-ForHttp -Url "http://127.0.0.1:5000/" -TimeoutSeconds 60
+
+if ($flaskReady) {
+    Write-Host "Flask is responding." -ForegroundColor Green
+} else {
+    Write-Host "Warning: Flask did not become ready within 60s. Opening browser anyway." -ForegroundColor Yellow
+}
+
+# 2) Wait for Expo/Metro
+# Common ports: 8081 (Metro), 19000/19001 (older Expo), 19006 (web).
+# If your splash page is served by the frontend, wait for that URL directly.
+$expoReady = Wait-ForTcpPort -HostName "127.0.0.1" -Port 8081 -TimeoutSeconds 90
+
+if ($expoReady) {
+    Write-Host "Expo/Metro port is open." -ForegroundColor Green
+} else {
+    Write-Host "Warning: Expo/Metro did not become ready within 90s." -ForegroundColor Yellow
+}
 
 Write-Host ""
-Write-Host "======================================" -ForegroundColor Cyan
-Write-Host "Setup Complete!" -ForegroundColor Green
-Write-Host "======================================" -ForegroundColor Cyan
-Write-Host ""
-Write-Host "Backend API: http://127.0.0.1:5000" -ForegroundColor Cyan
-Write-Host "API Health: http://127.0.0.1:5000/api/health" -ForegroundColor Cyan
-Write-Host ""
-Write-Host "Expo development server should open automatically." -ForegroundColor Cyan
-Write-Host "Check the PowerShell windows for Flask and Expo logs." -ForegroundColor Cyan
-Write-Host ""
-Write-Host "Press any key to exit this script (servers will continue running)..." -ForegroundColor Gray
-$null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+Write-Host "Opening browser..." -ForegroundColor Yellow
+
+# If this page is served by Expo/React Native web, waiting for Expo is the key.
+Start-Process "http://localhost:8081/splash"


### PR DESCRIPTION
# Description

Adds 2 scripts; one for automatically starting the application environment (`start-dev`), and another for automatically setting up and training models (`train`).

- `start-dev` creates a venv and install dependencies (if not done already), initializes needed databases, starts the FLask server, and goes to the frontend and starts the expo server.
- You can test it out by running `.\start-dev.ps1` in the root directory of cu-bytes.

- `train` runs the full ML pipelines from venv initialization -> hardware checking -> data download -> training.
- Both scripts have a bash and powershell variant
- **Note**, if you want to test out the `train.ps1` script make sure you *disable* any datasets you don't want downloaded locally (switching enabled from true to false in `datasets_config.json`)

Fixes #48 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [x] Manual tests
- [ ] Linted/formatted

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
