### PR TITLE
fix: for food items where nutrients is -1, display as 'unknown' and logging messages vanish after 800 ms

### DIFF
--- a/frontend/cu-bytes/app/dining.tsx
+++ b/frontend/cu-bytes/app/dining.tsx
@@ -124,7 +124,107 @@ export default function DiningScreen() {
         else {
             return cost
         }
-   }   
+   }
+
+    /*
+        Calculate how to display the amount of carbs for the selected food item
+        If the value of the carbs_g key is -1, then there is an "Unknown" amount of carbs for the food item
+        If the value of the carbs_g key is not -1, then the displayed amount of carbs is equal to that of the carbs_g key value
+
+        param(s):
+            carbs - number : The amount of carbs in grams for the selected food item, as per the carbs_g key value
+
+        returns : The amount of carbs for the selected food item
+    */
+   function processFoodItemCarbs(carbs: number) {
+
+        if (carbs == -1) {
+            return "Unknown"
+        }
+        else {
+            return carbs
+        }
+   }
+
+    /*
+        Calculate how to display the amount of fat for the selected food item
+        If the value of the fat_g key is -1, then there is an "Unknown" amount of fat for the food item
+        If the value of the fat_g key is not -1, then the displayed amount of fat is equal to that of the fat_g key value
+
+        param(s):
+            fat - number : The amount of fat in grams for the selected food item, as per the fat key value
+
+        returns : The amount of fat for the selected food item
+    */
+   function processFoodItemFat(fat: number) {
+
+        if (fat == -1) {
+            return "Unknown"
+        }
+        else {
+            return fat
+        }
+   }
+
+    /*
+        Calculate how to display the amount of fiber for the selected food item
+        If the value of the fiber_g key is -1, then there is an "Unknown" amount of fiber for the food item
+        If the value of the fiber_g key is not -1, then the displayed amount of fiber is equal to that of the fiber_g key value
+
+        param(s):
+            fiber - number : The amount of fiber in grams for the selected food item, as per the fiber key value
+
+        returns : The amount of fiber for the selected food item
+    */
+   function processFoodItemFiber(fiber: number) {
+
+        if (fiber == -1) {
+            return "Unknown"
+        }
+        else {
+            return fiber
+        }
+   }
+
+    /*
+        Calculate how to display the amount of proteins for the selected food item
+        If the value of the proteins_g key is -1, then there is an "Unknown" amount of proteins for the food item
+        If the value of the proteins_g key is not -1, then the displayed amount of proteins is equal to that of the proteins_g key value
+
+        param(s):
+            proteins - number : The amount of proteins in grams for the selected food item, as per the proteins key value
+
+        returns : The amount of proteins for the selected food item
+    */
+   function processFoodItemProteins(proteins: number) {
+
+        if (proteins == -1) {
+            return "Unknown"
+        }
+        else {
+            return proteins
+        }
+   }
+
+    /*
+        Calculate how to display the amount of sugar for the selected food item
+        If the value of the sugar_g key is -1, then there is an "Unknown" amount of sugar for the food item
+        If the value of the sugar_g key is not -1, then the displayed amount of sugar is equal to that of the sugar_g key value
+
+        param(s):
+            sugar - number : The amount of sugar in grams for the selected food item, as per the sugar key value
+
+        returns : The amount of sugar for the selected food item
+    */
+   function processFoodItemSugar(sugar: number) {
+
+        if (sugar == -1) {
+            return "Unknown"
+        }
+        else {
+            return sugar
+        }
+   }
 
     /*
         Send a request to the backend endpoint to get all food items from the database
@@ -377,15 +477,15 @@ export default function DiningScreen() {
                     {'\n'}
                     Cost: $ {processFoodItemCost(foodItem.cost)}
                     {'\n'}
-                    Carbs: {foodItem.carbs_g} grams
+                    Carbs: {processFoodItemCarbs(foodItem.carbs_g)} grams
                     {'\n'}
-                    Fat: {foodItem.fat_g} grams
+                    Fat: {processFoodItemFat(foodItem.fat_g)} grams
                     {'\n'}
-                    Fiber: {foodItem.fiber_g} grams
+                    Fiber: {processFoodItemFiber(foodItem.fiber_g)} grams
                     {'\n'}
-                    Proteins: {foodItem.proteins_g} grams
+                    Proteins: {processFoodItemProteins(foodItem.proteins_g)} grams
                     {'\n'}
-                    Sugar: {foodItem.sugar_g} grams
+                    Sugar: {processFoodItemSugar(foodItem.sugar_g)} grams
                     {'\n'}
 
                     {foodItem.has_eggs === true && hasEggAllergyGlobal ? "Warning - this item contains eggs" : null}
@@ -436,6 +536,11 @@ export default function DiningScreen() {
                         logFoodItemById(foodItem.id);
                         setFoodItemsVisible(true);
                         setModalVisible(true);
+
+                        setModalVisible(true);
+                        setTimeout(() => {
+                        setModalVisible(false);
+                        }, 800);
                     }}
                     disabled={loading}
                 >
@@ -448,20 +553,10 @@ export default function DiningScreen() {
                     animationType="fade"
                     transparent={true}
                     visible={modalVisible}
-                    onRequestClose={() => {
-                        Alert.alert('Modal has been closed.');
-                        setModalVisible(false);
-                    }}
                 >
                     <View>
                         <View>
                             <Text style={styles.subsubtitle}>Food Item Logged!</Text>
-                            <TouchableOpacity
-                                style={[styles.buttonPopup]}
-                                onPress={() => setModalVisible(false)}
-                            >
-                                <Text style={styles.buttonText}>Continue Browsing</Text>
-                            </TouchableOpacity>
                         </View>
                     </View>
                 </Modal>

--- a/frontend/cu-bytes/app/dining.tsx
+++ b/frontend/cu-bytes/app/dining.tsx
@@ -4,7 +4,6 @@ import { View, Text, TextInput, TouchableOpacity, ActivityIndicator, Alert, Moda
 import { router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 
-
 import { useUser } from './context';
 import { styles } from "./styles/style-dining";
 
@@ -440,9 +439,8 @@ export default function DiningScreen() {
                                 setDiningLocationsVisible(false);
                             }}
                         >
-                            {diningLocation["name"]}{"\n"}(ID {diningLocation["id"]})
-                            <br></br>
-                            <line>---</line>
+                            {diningLocation["name"]} (ID {diningLocation["id"]})
+                            {"\n"}
                         </Text>
                     ))}
                 </View>
@@ -459,9 +457,8 @@ export default function DiningScreen() {
                                 setFoodItemsVisible(false);
                             }}
                         >
-                            {foodItem["name"]}{"\n"}(ID {foodItem["id"]})
-                            <br></br>
-                            <line>---</line>
+                            {foodItem["name"]} (ID {foodItem["id"]})
+                            {"\n"}
                         </Text>
                     ))}
                 </View>
@@ -540,7 +537,9 @@ export default function DiningScreen() {
                         setModalVisible(true);
                         setTimeout(() => {
                         setModalVisible(false);
-                        }, 800);
+                        }, 2000);
+
+                        router.push("/home");
                     }}
                     disabled={loading}
                 >

--- a/frontend/cu-bytes/app/enter.tsx
+++ b/frontend/cu-bytes/app/enter.tsx
@@ -128,6 +128,106 @@ export default function EnterScreen() {
    }
 
     /*
+        Calculate how to display the amount of carbs for the selected food item
+        If the value of the carbs_g key is -1, then there is an "Unknown" amount of carbs for the food item
+        If the value of the carbs_g key is not -1, then the displayed amount of carbs is equal to that of the carbs_g key value
+
+        param(s):
+            carbs - number : The amount of carbs in grams for the selected food item, as per the carbs_g key value
+
+        returns : The amount of carbs for the selected food item
+    */
+   function processFoodItemCarbs(carbs: number) {
+
+        if (carbs == -1) {
+            return "Unknown"
+        }
+        else {
+            return carbs
+        }
+   }
+
+    /*
+        Calculate how to display the amount of fat for the selected food item
+        If the value of the fat_g key is -1, then there is an "Unknown" amount of fat for the food item
+        If the value of the fat_g key is not -1, then the displayed amount of fat is equal to that of the fat_g key value
+
+        param(s):
+            fat - number : The amount of fat in grams for the selected food item, as per the fat key value
+
+        returns : The amount of fat for the selected food item
+    */
+   function processFoodItemFat(fat: number) {
+
+        if (fat == -1) {
+            return "Unknown"
+        }
+        else {
+            return fat
+        }
+   }
+
+    /*
+        Calculate how to display the amount of fiber for the selected food item
+        If the value of the fiber_g key is -1, then there is an "Unknown" amount of fiber for the food item
+        If the value of the fiber_g key is not -1, then the displayed amount of fiber is equal to that of the fiber_g key value
+
+        param(s):
+            fiber - number : The amount of fiber in grams for the selected food item, as per the fiber key value
+
+        returns : The amount of fiber for the selected food item
+    */
+   function processFoodItemFiber(fiber: number) {
+
+        if (fiber == -1) {
+            return "Unknown"
+        }
+        else {
+            return fiber
+        }
+   }
+
+    /*
+        Calculate how to display the amount of proteins for the selected food item
+        If the value of the proteins_g key is -1, then there is an "Unknown" amount of proteins for the food item
+        If the value of the proteins_g key is not -1, then the displayed amount of proteins is equal to that of the proteins_g key value
+
+        param(s):
+            proteins - number : The amount of proteins in grams for the selected food item, as per the proteins key value
+
+        returns : The amount of proteins for the selected food item
+    */
+   function processFoodItemProteins(proteins: number) {
+
+        if (proteins == -1) {
+            return "Unknown"
+        }
+        else {
+            return proteins
+        }
+   }
+
+    /*
+        Calculate how to display the amount of sugar for the selected food item
+        If the value of the sugar_g key is -1, then there is an "Unknown" amount of sugar for the food item
+        If the value of the sugar_g key is not -1, then the displayed amount of sugar is equal to that of the sugar_g key value
+
+        param(s):
+            sugar - number : The amount of sugar in grams for the selected food item, as per the sugar key value
+
+        returns : The amount of sugar for the selected food item
+    */
+   function processFoodItemSugar(sugar: number) {
+
+        if (sugar == -1) {
+            return "Unknown"
+        }
+        else {
+            return sugar
+        }
+   }
+
+    /*
         Send a request to the backend endpoint to get all food items from the database
     */
     useEffect(() => {
@@ -291,15 +391,15 @@ export default function EnterScreen() {
                     {'\n'}
                     Cost: $ {processFoodItemCost(foodItem.cost)}
                     {'\n'}
-                    Carbs: {foodItem.carbs_g} grams
+                    Carbs: {processFoodItemCarbs(foodItem.carbs_g)} grams
                     {'\n'}
-                    Fat: {foodItem.fat_g} grams
+                    Fat: {processFoodItemFat(foodItem.fat_g)} grams
                     {'\n'}
-                    Fiber: {foodItem.fiber_g} grams
+                    Fiber: {processFoodItemFiber(foodItem.fiber_g)} grams
                     {'\n'}
-                    Proteins: {foodItem.proteins_g} grams
+                    Proteins: {processFoodItemProteins(foodItem.proteins_g)} grams
                     {'\n'}
-                    Sugar: {foodItem.sugar_g} grams
+                    Sugar: {processFoodItemSugar(foodItem.sugar_g)} grams
                     {'\n'}
  
                     {foodItem.has_eggs === true && hasEggAllergyGlobal ? "Warning - this item contains eggs \n" : null}
@@ -349,7 +449,11 @@ export default function EnterScreen() {
                     onPress={() => {
                         logFoodItemById(foodItem.id);
                         setVisible(false);
+                        
                         setModalVisible(true);
+                        setTimeout(() => {
+                        setModalVisible(false);
+                        }, 800);
                     }}
                     disabled={loading}
                 >
@@ -362,20 +466,10 @@ export default function EnterScreen() {
                     animationType="fade"
                     transparent={true}
                     visible={modalVisible}
-                    onRequestClose={() => {
-                        Alert.alert('Modal has been closed.');
-                        setModalVisible(false);
-                    }}
                 >
                     <View>
                         <View>
                             <Text style={styles.subsubtitle}>Food Item Logged!</Text>
-                            <TouchableOpacity
-                                style={[styles.buttonPopup]}
-                                onPress={() => setModalVisible(false)}
-                            >
-                                <Text style={styles.buttonText}>Continue Browsing</Text>
-                            </TouchableOpacity>
                         </View>
                     </View>
                 </Modal>

--- a/frontend/cu-bytes/app/enter.tsx
+++ b/frontend/cu-bytes/app/enter.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
 import { View, Text, TextInput, TouchableOpacity, ActivityIndicator, Alert, Modal } from 'react-native';
+
+import { router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 
 import { styles } from './styles/style-enter';
@@ -453,7 +455,9 @@ export default function EnterScreen() {
                         setModalVisible(true);
                         setTimeout(() => {
                         setModalVisible(false);
-                        }, 800);
+                        }, 2000);
+
+                        router.push("/home");
                     }}
                     disabled={loading}
                 >

--- a/frontend/cu-bytes/app/entries.tsx
+++ b/frontend/cu-bytes/app/entries.tsx
@@ -76,6 +76,106 @@ export default function EntriesScreen() {
         }
     }
 
+    /*
+        Calculate how to display the amount of carbs for the selected food item
+        If the value of the carbs_g key is -1, then there is an "Unknown" amount of carbs for the food item
+        If the value of the carbs_g key is not -1, then the displayed amount of carbs is equal to that of the carbs_g key value
+
+        param(s):
+            carbs - number : The amount of carbs in grams for the selected food item, as per the carbs_g key value
+
+        returns : The amount of carbs for the selected food item
+    */
+   function processFoodItemCarbs(carbs: number) {
+
+        if (carbs == -1) {
+            return "Unknown"
+        }
+        else {
+            return carbs
+        }
+   }
+
+    /*
+        Calculate how to display the amount of fat for the selected food item
+        If the value of the fat_g key is -1, then there is an "Unknown" amount of fat for the food item
+        If the value of the fat_g key is not -1, then the displayed amount of fat is equal to that of the fat_g key value
+
+        param(s):
+            fat - number : The amount of fat in grams for the selected food item, as per the fat key value
+
+        returns : The amount of fat for the selected food item
+    */
+   function processFoodItemFat(fat: number) {
+
+        if (fat == -1) {
+            return "Unknown"
+        }
+        else {
+            return fat
+        }
+   }
+
+    /*
+        Calculate how to display the amount of fiber for the selected food item
+        If the value of the fiber_g key is -1, then there is an "Unknown" amount of fiber for the food item
+        If the value of the fiber_g key is not -1, then the displayed amount of fiber is equal to that of the fiber_g key value
+
+        param(s):
+            fiber - number : The amount of fiber in grams for the selected food item, as per the fiber key value
+
+        returns : The amount of fiber for the selected food item
+    */
+   function processFoodItemFiber(fiber: number) {
+
+        if (fiber == -1) {
+            return "Unknown"
+        }
+        else {
+            return fiber
+        }
+   }
+
+    /*
+        Calculate how to display the amount of proteins for the selected food item
+        If the value of the proteins_g key is -1, then there is an "Unknown" amount of proteins for the food item
+        If the value of the proteins_g key is not -1, then the displayed amount of proteins is equal to that of the proteins_g key value
+
+        param(s):
+            proteins - number : The amount of proteins in grams for the selected food item, as per the proteins key value
+
+        returns : The amount of proteins for the selected food item
+    */
+   function processFoodItemProteins(proteins: number) {
+
+        if (proteins == -1) {
+            return "Unknown"
+        }
+        else {
+            return proteins
+        }
+   }
+
+    /*
+        Calculate how to display the amount of sugar for the selected food item
+        If the value of the sugar_g key is -1, then there is an "Unknown" amount of sugar for the food item
+        If the value of the sugar_g key is not -1, then the displayed amount of sugar is equal to that of the sugar_g key value
+
+        param(s):
+            sugar - number : The amount of sugar in grams for the selected food item, as per the sugar key value
+
+        returns : The amount of sugar for the selected food item
+    */
+   function processFoodItemSugar(sugar: number) {
+
+        if (sugar == -1) {
+            return "Unknown"
+        }
+        else {
+            return sugar
+        }
+   }
+
     // Display loading symbol while the food items are being fetched
     if (loading) {
         return (
@@ -115,15 +215,15 @@ export default function EntriesScreen() {
                             <br></br>
                             Calories: {processFoodItemCalories(foodItem["calories"])}
                             <br></br>
-                            Carbs: {foodItem["carbs_g"]} grams
+                            Carbs: {processFoodItemCarbs(foodItem["carbs_g"])} grams
                             <br></br>
-                            Fat: {foodItem["fat_g"]} grams
+                            Fat: {processFoodItemFat(foodItem["fat_g"])} grams
                             <br></br>
-                            Fiber: {foodItem["fiber_g"]} grams
+                            Fiber: {processFoodItemFiber(foodItem["fiber_g"])} grams
                             <br></br>
-                            Proteins: {foodItem["proteins_g"]} grams
+                            Proteins: {processFoodItemProteins(foodItem["proteins_g"])} grams
                             <br></br>
-                            Sugar: {foodItem["sugar_g"]} grams
+                            Sugar: {processFoodItemSugar(foodItem["sugar_g"])} grams
                             <br></br>
                             {foodItem["transaction_time"]}
                             <br></br>

--- a/frontend/cu-bytes/app/register.tsx
+++ b/frontend/cu-bytes/app/register.tsx
@@ -109,8 +109,8 @@ export default function RegisterScreen() {
                 setIsVegetarianGlobal(false),
                 setPrefersHalalGlobal(false),
                 
-                // Route to the login page
-                router.push("/login");
+                // Route to the home page
+                router.push("/home");
             }
         })
 

--- a/frontend/cu-bytes/app/scan.tsx
+++ b/frontend/cu-bytes/app/scan.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { View, Text, TouchableOpacity, Image, Alert, Modal, ActivityIndicator } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+
 import { router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { apiService } from '../services/api';
@@ -352,7 +353,9 @@ export default function ScanScreen() {
                             setModalVisible(true);
                             setTimeout(() => {
                             setModalVisible(false);
-                            }, 800);
+                            }, 2000);
+
+                            router.push('/home');
                         }}
                         disabled={loading}
                     >
@@ -366,10 +369,6 @@ export default function ScanScreen() {
                     animationType="fade"
                     transparent={true}
                     visible={modalVisible}
-                    onRequestClose={() => {
-                        Alert.alert('Modal has been closed.');
-                        setModalVisible(false);
-                    }}
                 >
                     <View>
                         <View>

--- a/frontend/cu-bytes/app/scan.tsx
+++ b/frontend/cu-bytes/app/scan.tsx
@@ -158,6 +158,106 @@ export default function ScanScreen() {
         }
     }
 
+    /*
+        Calculate how to display the amount of carbs for the selected food item
+        If the value of the carbs_g key is -1, then there is an "Unknown" amount of carbs for the food item
+        If the value of the carbs_g key is not -1, then the displayed amount of carbs is equal to that of the carbs_g key value
+
+        param(s):
+            carbs - number : The amount of carbs in grams for the selected food item, as per the carbs_g key value
+
+        returns : The amount of carbs for the selected food item
+    */
+   function processFoodItemCarbs(carbs: number) {
+
+        if (carbs == -1) {
+            return "Unknown"
+        }
+        else {
+            return carbs
+        }
+   }
+
+    /*
+        Calculate how to display the amount of fat for the selected food item
+        If the value of the fat_g key is -1, then there is an "Unknown" amount of fat for the food item
+        If the value of the fat_g key is not -1, then the displayed amount of fat is equal to that of the fat_g key value
+
+        param(s):
+            fat - number : The amount of fat in grams for the selected food item, as per the fat key value
+
+        returns : The amount of fat for the selected food item
+    */
+   function processFoodItemFat(fat: number) {
+
+        if (fat == -1) {
+            return "Unknown"
+        }
+        else {
+            return fat
+        }
+   }
+
+    /*
+        Calculate how to display the amount of fiber for the selected food item
+        If the value of the fiber_g key is -1, then there is an "Unknown" amount of fiber for the food item
+        If the value of the fiber_g key is not -1, then the displayed amount of fiber is equal to that of the fiber_g key value
+
+        param(s):
+            fiber - number : The amount of fiber in grams for the selected food item, as per the fiber key value
+
+        returns : The amount of fiber for the selected food item
+    */
+   function processFoodItemFiber(fiber: number) {
+
+        if (fiber == -1) {
+            return "Unknown"
+        }
+        else {
+            return fiber
+        }
+   }
+
+    /*
+        Calculate how to display the amount of proteins for the selected food item
+        If the value of the proteins_g key is -1, then there is an "Unknown" amount of proteins for the food item
+        If the value of the proteins_g key is not -1, then the displayed amount of proteins is equal to that of the proteins_g key value
+
+        param(s):
+            proteins - number : The amount of proteins in grams for the selected food item, as per the proteins key value
+
+        returns : The amount of proteins for the selected food item
+    */
+   function processFoodItemProteins(proteins: number) {
+
+        if (proteins == -1) {
+            return "Unknown"
+        }
+        else {
+            return proteins
+        }
+   }
+
+    /*
+        Calculate how to display the amount of sugar for the selected food item
+        If the value of the sugar_g key is -1, then there is an "Unknown" amount of sugar for the food item
+        If the value of the sugar_g key is not -1, then the displayed amount of sugar is equal to that of the sugar_g key value
+
+        param(s):
+            sugar - number : The amount of sugar in grams for the selected food item, as per the sugar key value
+
+        returns : The amount of sugar for the selected food item
+    */
+   function processFoodItemSugar(sugar: number) {
+
+        if (sugar == -1) {
+            return "Unknown"
+        }
+        else {
+            return sugar
+        }
+   }
+
     return (
         <View style={styles.container}>
             <StatusBar style="auto" />
@@ -189,15 +289,15 @@ export default function ScanScreen() {
                         {'\n'}
                         Confidence: {prediction.confidence}%
                         {'\n'}
-                        Carbs: {prediction.carbs_g != null ? prediction.carbs_g : 0.00 } grams
+                        Carbs: {prediction.carbs_g != null ? processFoodItemCarbs(prediction.carbs_g) : "Unknown" } grams
                         {'\n'}
-                        Fat: {prediction.fat_g != null ? prediction.fat_g : 0.00 } grams
+                        Fat: {prediction.fat_g != null ? processFoodItemFat(prediction.fat_g) : "Unknown" } grams
                         {'\n'}
-                        Fiber: {prediction.fiber_g != null ? prediction.fiber_g : 0.00 } grams
+                        Fiber: {prediction.fiber_g != null ? processFoodItemFiber(prediction.fiber_g) : "Unknown" } grams
                         {'\n'}
-                        Proteins: {prediction.proteins_g != null ? prediction.proteins_g : 0.00 } grams
+                        Proteins: {prediction.proteins_g != null ? processFoodItemProteins(prediction.proteins_g) : "Unknown" } grams
                         {'\n'}
-                        Sugar: {prediction.sugar_g != null ? prediction.sugar_g : 0.00 } grams
+                        Sugar: {prediction.sugar_g != null ? processFoodItemSugar(prediction.sugar_g) : "Unknown" } grams
                         {'\n'}
 
                         {prediction.confidence >= 75 && prediction.has_eggs === true && hasEggAllergyGlobal ? "Warning - this item contains eggs \n" : null}
@@ -248,11 +348,15 @@ export default function ScanScreen() {
                         style={[styles.button, loading && styles.buttonDisabled]}
                         onPress={() => {
                             handlePressLogFoodItemByName(prediction.food_name);
+                            
                             setModalVisible(true);
+                            setTimeout(() => {
+                            setModalVisible(false);
+                            }, 800);
                         }}
                         disabled={loading}
                     >
-                        <Text style={styles.buttonText}>Add Food Item</Text>
+                        <Text style={styles.buttonText}>Log Food Item</Text>
                     </TouchableOpacity>
                 </View>
             )}
@@ -270,12 +374,6 @@ export default function ScanScreen() {
                     <View>
                         <View>
                             <Text style={styles.subsubtitle}>Food Item Logged!</Text>
-                            <TouchableOpacity
-                                style={[styles.buttonPopup]}
-                                onPress={() => setModalVisible(false)}
-                            >
-                                <Text style={styles.buttonText}>Continue Browsing</Text>
-                            </TouchableOpacity>
                         </View>
                     </View>
                 </Modal>


### PR DESCRIPTION
# Description

On the scan, enter, dining, and entries pages on the frontend, display -1 nutrients values as "Unknown"
On the scan, enter, and dining pages on the frontend, display the "Food Item Logged!" message for 2000 ms and route to the home page
Creating an account on the register page now routes to the home page instead of the login page

Please include a summary of the changes and the related issue.

Fixes # (issue)

- https://github.com/GAchuzia/cu-bytes/issues/87
- https://github.com/GAchuzia/cu-bytes/issues/91
- https://github.com/GAchuzia/cu-bytes/issues/93

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [X] Unit tests
- [X] Manual tests
- [ ] Linted/formatted

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
