### PR TITLE
Feature/backend fix all browsing endpoints

### DIFF
--- a/backend/automated_data_collection/FoodInfo.csv
+++ b/backend/automated_data_collection/FoodInfo.csv
@@ -487,7 +487,7 @@ Popcorn Shrimp,Mike's Place,7.49,,,N,N,N,N,Y,,,N,N,N,N,N,,Y,10/1/2025,Shrimp
 Pork Sausage,Riverbank Social,3.99,,N,N,N,N,N,Y,,N,N,N,N,N,N,N,N,1/13/2026,Sausage
 Pork Souvlaki,Teraanga Commons Dining Hall,,190.0,,F,T,F,F,Y,,N,N,N,N,N,,N,N,10/6/2025,Pork
 Potato Caesar Salad,Urban Deli,4.8,420.0,N,N,N,N,N,N,,Y,N,Y,N,N,N,N,Y,9/26/2025,Potato Salad
-Potato Wedges,Teraanga Commons Dining Hall,,110.0,,F,F,F,F,,,N,N,,N,N,,N,N,10/6/2025,Fries
+Potato Wedges,Teraanga Commons Dining Hall,,110.0,,F,F,F,F,,,N,N,,N,N,,N,N,10/6/2025,French Fries
 Potato Wedges with Fry Sauce,Colonel by Chicken,4.2,760.0,N,N,Y,Y,Y,Y,Our delicious seasoned potato wedges served with our homemade fry sauce,N,N,N,N,N,N,N,N,1/14/2026,French Fries
 "Potato, Cheddar & Chive Bakes",Starbucks,6.25,210.0,N,N,N,,N,N,,Y,N,Y,N,N,N,N,N,1/15/2026,Potato
 Poutine,Burger 101,9.6,1400.0,N,N,N,Y,Y,N,"Our crispy fries topped with cheese curds, mushroom gravy and onion rings",N,N,Y,N,N,N,N,N,1/14/2026,Poutine
@@ -638,7 +638,7 @@ Vegetable Spring Rolls,Mike's Place,5.99,,,N,N,Y,Y,Y,,,N,N,N,,N,,Y,10/1/2025,Spr
 Vegetarian California Roll,Bento Boxes,9.0,270.0,N,Y,Y,Y,Y,Y,"Carrots, cucumber and avocado wrapped in seaweed and rice",N,N,N,N,Y,N,N,N,1/14/2025,Sushi
 Vegetarian Poutine,Burger 101,9.6,,N,,N,Y,Y,N,,N,N,Y,N,N,N,N,N,1/14/2026,Poutine
 Veggie Burrito,Bridgehead,10.95,,N,N,N,Y,Y,,,N,Y,,,N,N,,Y,9/24/2025,Burrito
-Veggie Patty,Rooster's,10.99,,N,Y,,Y,Y,Y,"Half a soy based vegitarian patty, wonderfully seasoned with your choice of toppings.",N,N,N,N,N,Y,N,Y,10/30/2025,Burger
+Veggie Patty,Rooster's,10.99,,N,Y,,Y,Y,Y,"Half a soy based vegitarian patty, wonderfully seasoned with your choice of toppings.",N,N,N,N,N,Y,N,Y,10/30/2025,Hamburger
 Veggie Patty Pita,Rooster's,10.99,,N,,N,Y,Y,Y,,N,N,N,N,N,Y,N,Y,1/13/2026,Pita With Protein
 Veggie Pho (200 gram),Teraanga Commons Dining Hall,,130.0,,T,T,F,T,Y,"tofu, onion, mushroom, pho vegetable broth, rice noodles, cilantro, green onion",N,,N,N,,Y,N,N,10/6/2025,Noodles
 Veggie Pita,Rooster's,8.69,,N,Y,N,Y,Y,Y,Your choice of our wide selection of fresh veggies.,N,N,N,N,N,N,N,Y,10/30/2025,Veggie pita

--- a/backend/automated_data_collection/cafFoodInfo.csv
+++ b/backend/automated_data_collection/cafFoodInfo.csv
@@ -1,184 +1,184 @@
 Food Item,Dining Location,Cost,Calories,Nuts,Vegan,Gluten Free,Halal,Vegetarian,No Dairy,Comments,Eggs,Fish,Milk,Peanuts,Sesame,Soy,TreeNuts,Wheat,Last Updated,Food Category
-Alfredo Sauce (3000  millilitre),Teraanga Commons Dining Hall,,,,F,T,F,F,,,,,,,,,,,10/6/2025,Sauce
-Apple Cabbage Slaw,Teraanga Commons Dining Hall,,60,,F,T,F,T,,,,,,,,,,,10/6/2025,Coleslaw
-Aromatic Basmati Rice,Teraanga Commons Dining Hall,,120,,T,T,F,T,,,,,,,,,,,10/6/2025,Rice
-Asian Noodle Salad (1000  gram),Teraanga Commons Dining Hall,,,,F,F,F,T,,"rice noodles, snow peas, broccoli, cucumber, carrot, onion, sesame seeds, spicy asian vinaigrette",,,,,,,,,10/6/2025,Pasta Salad
-Asian Tofu (59  millilitre),Teraanga Commons Dining Hall,,45,,T,F,F,T,,,,,,,,,,,10/6/2025,Tofu
-Baby Kale,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,10/6/2025,Kale
-Bacon Cheeseburger Pizza,Teraanga Commons Dining Hall,,210,,F,F,F,F,,"ground beef, bacon, red onion, mozzarella, 3 cheese blend",,,,,,,,,10/6/2025,Pizza
-Baked Chicken Thighs,Teraanga Commons Dining Hall,,,,F,T,F,F,,,,,,,,,,,10/6/2025,Chicken
-Balsamic Glaze,Teraanga Commons Dining Hall,,35,,T,T,F,T,,,,,,,,,,,10/6/2025,Sauce
-BBQ Tofu Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,T,,"tofu, red onion, cilantro, BBQ tomato base, mozzarella",,,,,,,,,10/6/2025,Pizza
-Bean Ragout,Teraanga Commons Dining Hall,,130,,T,T,F,T,,"kidney beans, chickpeas, onion, green pepper, carrot, tomato",,,,,,,,,10/6/2025,Stew
-Beef Quesadilla,Teraanga Commons Dining Hall,,280,,F,F,F,F,,"taco-spiced ground beef, cheddar cheese, tortilla",,,,,,,,,10/6/2025,Quesadilla
-Black Forest Cake,Teraanga Commons Dining Hall,,190,,F,F,F,F,,,,,,,,,,,10/6/2025,Cake
-Black Olives,Teraanga Commons Dining Hall,,25,,T,T,F,T,,,,,,,,,,,10/6/2025,Olive
-Blondie,Teraanga Commons Dining Hall,,310,,F,F,F,T,,,,,,,,,,,10/6/2025,Brownie
-Blueberry Tart,Teraanga Commons Dining Hall,,120,,F,F,F,F,,,,,,,,,,,10/6/2025,Tart
-Bok Choy,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
-Braised Beef Ragu (3000  millilitre),Teraanga Commons Dining Hall,,160,,F,T,F,F,,,,,,,,,,,10/6/2025,Stew
-Broccoli,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,10/6/2025,Broccoli
-Buffalo Chicken Pizza,Teraanga Commons Dining Hall,,180,,F,F,F,F,,"spicy buffalo chicken, red onion, buffalo sauce, mozzarella, blue cheese",,,,,,,,,10/6/2025,Pizza
-Buffalo Ranch Potato Salad (1000  gram),Teraanga Commons Dining Hall,,140,,F,T,F,F,,"red potatoes, red pepper, celery, green onion, buffalo ranch dressing",,,,,,,,,10/6/2025,Potato Salad
-Cajun Chicken Thigh,Teraanga Commons Dining Hall,,210,,F,F,F,F,,,,,,,,,,,10/6/2025,Chicken
-Cajun-Style Dirty Rice,Teraanga Commons Dining Hall,,160,,T,T,F,T,,"black beans, onion, red pepper, celery, peas, spices, brown rice",,,,,,,,,10/6/2025,Fried Rice
-Canadian Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,F,,"pepperoni, bacon, mushroom, mozzarella",,,,,,,,,10/6/2025,Pizza
-Caramel Coffee Cake,Teraanga Commons Dining Hall,,300,,F,F,F,F,,,,,,,,,,,10/6/2025,Cake
-Carrot (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,10/6/2025,Carrot
-Cauliflower Bulgur Curry,Teraanga Commons Dining Hall,,160,,T,F,F,T,,"lentil, bulgur, cauliflower, red pepper, onion, coconut milk",,,,,,,,,10/6/2025,Curry (Vegetable)
-Cauliflower Lentil Wrap,Teraanga Commons Dining Hall,,260,,T,F,F,T,,"cauliflower & red lentil curry, basmati rice, tortilla",,,,,,,,,10/6/2025,Wrap (No protein)
-Chasu Pork Loin (1  slice),Teraanga Commons Dining Hall,,70,,F,F,F,F,,,,,,,,,,,10/6/2025,Pork
-Cheese Pizza,Teraanga Commons Dining Hall,,150,,F,F,F,T,,,,,,,,,,,10/6/2025,Pizza (Cheese)
-Chicken & Corn Chowder,Teraanga Commons Dining Hall,,,,F,F,F,F,,"A creamy chowder loaded with chicken breast pieces, corn and potatoes.",,,,,,,,,10/6/2025,Chowder
-Chicken Bruschetta Penne Alfredo,Teraanga Commons Dining Hall,,230,,F,F,F,F,,"chicken breast, tomato, basil, parmesan, alfredo sauce, penne",,,,,,,,,10/6/2025,Pasta
-Chicken Pho,Teraanga Commons Dining Hall,,410,,F,F,F,F,,,,,,,,,,,10/6/2025,Noodles
-Chicken Tinga Taco,Teraanga Commons Dining Hall,,240,,F,F,F,F,,"chicken tinga, lettuce, tomato, sour cream, cheddar cheese, tortilla",,,,,,,,,10/6/2025,Taco
-Chickpea & Root Vegetable Soup (8000  millilitre),Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,10/6/2025,Soup
-Chickpea Curry,Teraanga Commons Dining Hall,,150,,F,T,F,T,,,,,,,,,,,10/6/2025,Curry
-Chickpea Panzanella Ricotta Salad,Teraanga Commons Dining Hall,,340,,F,F,F,F,,"crispy pesto chickpeas, ricotta, kalamata olives, cucumber, tomato, celery, red pepper, capers, balsamic glaze",,,,,,,,,10/6/2025,Grain Salad
-Chickpea Shawarma Wrap,Teraanga Commons Dining Hall,,240,,T,F,F,T,,"smashed lemon tahini chickpeas, pickled red cabbage, cucumber, carrots, lettuce, garlic sauce, tortilla",,,,,,,,,10/6/2025,Wrap
-Chickpeas,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,10/6/2025,Chickpeas
-Chili Garlic Veggie Stir Fry,Teraanga Commons Dining Hall,,90,,T,F,F,T,,"cabbage, carrot, celery, onion, spices, sweet chili sauce, soy sauce",,,,,,,,,10/6/2025,Stir Fry
-Chocolate Chip Cookie,Teraanga Commons Dining Hall,,130,,F,F,F,T,,,,,,,,,,,10/6/2025,Cookie
-Chocolate Chip Rice Krispie Square,Teraanga Commons Dining Hall,,100,,F,F,F,F,,,,,,,,,,,10/6/2025,Square
-Club Sandwich,Teraanga Commons Dining Hall,,250,,F,F,F,F,,"bacon, ham, turkey, lettuce, tomato, cheddar cheese, mayo, whole wheat bread",,,,,,,,,10/6/2025,Sandwich
-Coconut Curry Chickpea Soup (474  millilitre),Teraanga Commons Dining Hall,,480,,T,T,F,T,,"Chickpeas, lentils and sweet potatoes simmered in coconut, ginger, turmeric and cinnamon flavours.",,,,,,,,,10/6/2025,Soup
-Coconut Jasmine Rice,Teraanga Commons Dining Hall,,190,,T,T,F,T,,,,,,,,,,,10/6/2025,Rice
-Confetti Rice Krispie Square,Teraanga Commons Dining Hall,,90,,F,F,F,F,,,,,,,,,,,10/6/2025,Square
-Corn,Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,10/6/2025,Corn
-Corn Lentil Soup (8000  millilitre),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,10/6/2025,Soup
-Cream of spinach soup,Teraanga Commons Dining Hall,,,,F,F,F,F,,,,,,,,,,,10/6/2025,Soup
-Creamy Chickpea Salad (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,"chickpeas, celery, green onion, red pepper, italian parsley, tahini lemon garlic vinaigrette",,,,,,,,,10/6/2025,Grain Salad
-Creamy Scrambled Egg,Teraanga Commons Dining Hall,,170,,F,F,F,F,,,,,,,,,,,10/6/2025,Egg
-Cucumber,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Cucumber
-Curried Carrots,Teraanga Commons Dining Hall,,80,,T,T,F,T,,,,,,,,,,,10/6/2025,Carrot
-Deli Roast Beef,Teraanga Commons Dining Hall,,140,,F,F,F,F,,Roast Beef,,,,,,,,,10/6/2025,Beef
-Dill Pickles,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Pickles
-Double Chocolate Cookie,Teraanga Commons Dining Hall,,160,,F,F,F,T,,,,,,,,,,,10/6/2025,Cookie
-Dried Cranberries,Teraanga Commons Dining Hall,,25,,T,T,F,T,,,,,,,,,,,10/6/2025,Cranberry
+Peameal Bacon,Teraanga Commons Dining Hall,,45,,F,T,F,F,,,,,,,,,,,10/6/2025,Bacon
 Edamame,Teraanga Commons Dining Hall,,60,,T,T,F,T,,,,,,,,,,,10/6/2025,Beans
-Egg (118  millilitre),Teraanga Commons Dining Hall,,180,,F,T,F,T,,,,,,,,,,,10/6/2025,Egg
-Egg Salad Baguette,Teraanga Commons Dining Hall,,200,,F,F,F,T,,"egg salad, lettuce, baguette",,,,,,,,,10/6/2025,Sandwich
-Egg White (118  millilitre),Teraanga Commons Dining Hall,,60,,F,T,F,T,,,,,,,,,,,10/6/2025,Egg
-Falafel,Teraanga Commons Dining Hall,,210,,T,T,F,T,,,,,,,,,,,10/6/2025,Falafel
-Farfalle,Teraanga Commons Dining Hall,,200,,T,F,F,T,,,,,,,,,,,10/6/2025,Pasta
-Fattoush Salad,Teraanga Commons Dining Hall,,60,,F,F,F,F,,"pita croutons, lettuce, cucumber, tomato, green pepper, red onion, lemon vinaigrette",,,,,,,,,10/6/2025,Green Salad
-Five Spice Chicken (90  millilitre),Teraanga Commons Dining Hall,,180,,F,T,F,F,,,,,,,,,,,10/6/2025,Chicken
-French Toast,Teraanga Commons Dining Hall,,120,,F,F,F,T,,,,,,,,,,,10/6/2025,Toast
-Garlic,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Garlic
+Green Beans,Teraanga Commons Dining Hall,,35,,T,T,F,T,,,,,,,,,,,10/6/2025,Beans
+Deli Roast Beef,Teraanga Commons Dining Hall,,140,,F,F,F,F,,Roast Beef,,,,,,,,,10/6/2025,Beef
+Ground Beef (1  kilogram),Teraanga Commons Dining Hall,,,,F,T,F,F,,,,,,,,,,,10/6/2025,Beef
+Seasoned Ground Beef,Teraanga Commons Dining Hall,,150,,F,T,F,F,,,,,,,,,,,10/6/2025,Beef
+Roasted Beets & Basil,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,10/6/2025,Beets
 Garlic Bread,Teraanga Commons Dining Hall,,170,,F,F,F,T,,,,,,,,,,,10/6/2025,Bread
 Garlic Croutons,Teraanga Commons Dining Hall,,60,,T,F,F,T,,,,,,,,,,,10/6/2025,Bread
-GF Broccoli Cheddar Soup,Teraanga Commons Dining Hall,,,,F,F,F,F,,A thick and delicious cheese soup with onions and broccoli florets.,,,,,,,,,10/6/2025,Soup
-Ginger Roasted Cauliflower & Carrots,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
-Goat Cheese & Vegetable Baguette,Teraanga Commons Dining Hall,,250,,F,F,F,F,,"mushroom, caramelized onion, spinach, zucchini, sundried tomato goat cheese",,,,,,,,,10/6/2025,Sandwich (No protein)
-Grainy Dijon Potato Salad (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,"mini red potatoes, mustard vinaigrette ",,,,,,,,,10/6/2025,Potato Salad
-Green Beans,Teraanga Commons Dining Hall,,35,,T,T,F,T,,,,,,,,,,,10/6/2025,Beans
-Green Onion,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Onion
-Green Peas,Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,10/6/2025,Peas
-Green Pepper,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Pepper
-Grilled Eggplant Pizza,Teraanga Commons Dining Hall,,180,,F,F,F,T,,"grilled eggplant, black olives, basil, chili pepper flakes, mozzarella",,,,,,,,,10/6/2025,Pizza (Vegetarian)
-Grilled Ham,Teraanga Commons Dining Hall,,30,,F,T,F,F,,,,,,,,,,,10/6/2025,Ham
-Grilled Vegetable Wrap,Teraanga Commons Dining Hall,,200,,F,F,F,F,,"grilled zucchini, roasted red pepper, spinach, sundried tomato pesto, tortilla",,,,,,,,,10/6/2025,Wrap (No protein)
-Ground Beef (1  kilogram),Teraanga Commons Dining Hall,,,,F,T,F,F,,,,,,,,,,,10/6/2025,Beef
-Ham (3  slice),Teraanga Commons Dining Hall,,60,,F,T,F,F,,,,,,,,,,,10/6/2025,Ham
-Ham (59  millilitre),Teraanga Commons Dining Hall,,30,,F,T,F,F,,,,,,,,,,,10/6/2025,Ham
-Hard Cooked Egg (1  piece),Teraanga Commons Dining Hall,,60,,F,T,F,T,,,,,,,,,,,10/6/2025,Egg
-Hash Brown,Teraanga Commons Dining Hall,,60,,F,F,F,F,,,,,,,,,,,10/6/2025,Hash Browns
-Hawaiian Pizza,Teraanga Commons Dining Hall,,170,,F,F,F,F,,"ham, pineapple, mozzarella",,,,,,,,,10/6/2025,Pizza
-Herb Roasted Chicken,Teraanga Commons Dining Hall,,170,,F,T,F,F,,,,,,,,,,,10/6/2025,Chicken
-Hoisin Chow Mein Salad (59  millilitre),Teraanga Commons Dining Hall,,40,,F,F,F,T,,"chow mein noodles, napa cabbage, cucumber, carrot, daikon radish, red peppers, green onion, sesame seeds, hoisin ginger vinaigrette",,,,,,,,,10/6/2025,Noodles
-Home Fried Potatoes,Teraanga Commons Dining Hall,,180,,F,F,F,F,,,,,,,,,,,10/6/2025,Potato
-Home Style Potatoes,Teraanga Commons Dining Hall,,90,,F,F,F,F,,,,,,,,,,,10/6/2025,Potato
-Hot Beef Sandwich,Teraanga Commons Dining Hall,,400,,F,F,F,F,,"roast beef, onion, mushroom,  gravy, bun",,,,,,,,,10/6/2025,Sandwich
-Hummus,Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,10/6/2025,Dip
-Jalapeno Coleslaw (1000  gram),Teraanga Commons Dining Hall,,,,F,T,F,T,,"cabbage, carrot, jalapenos, creamy dressing",,,,,,,,,10/6/2025,Coleslaw
-Jalapeno Popper Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,F,,"cream cheese, jalapeno peppers, red onions, monterey jack, bacon",,,,,,,,,10/6/2025,Pizza
-Kale Apple Chickpea Salad (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,"chickpeas, cauliflower, carrot, kale, red onion, apple, fresh parsley, maple dijon vinaigrette",,,,,,,,,10/6/2025,Grain Salad
-Kale Squash Gnocchi,Teraanga Commons Dining Hall,,320,,T,F,F,T,,"butternut squash, kale, sage, gnocchi",,,,,,,,,10/6/2025,Pasta
-Korean BBQ Tempeh Wrap,Teraanga Commons Dining Hall,,280,,T,F,F,T,,"korean BBQ tempeh, red pepper, green onion, guacamole, lettuce, sesame seeds, tortilla",,,,,,,,,10/6/2025,Wrap
-Korean Lentils,Teraanga Commons Dining Hall,,,,T,F,F,T,,,,,,,,,,,10/6/2025,Lentils
-Kung Pao Tofu,Teraanga Commons Dining Hall,,150,,T,F,F,T,,,,,,,,,,,10/6/2025,Tofu
-Lemon Buttermilk Cake,Teraanga Commons Dining Hall,,140,,F,F,F,F,,,,,,,,,,,10/6/2025,Cake
-Lemon Cookie,Teraanga Commons Dining Hall,,70,,F,F,F,F,,,,,,,,,,,10/6/2025,Cookie
-Lemon Garlic Vinaigrette,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,10/6/2025,Sauce
-Lentil Shepherd's Pie,Teraanga Commons Dining Hall,,150,,T,F,F,T,,"lentils, carrot, celery, gravy, spices, mashed potato",,,,,,,,,10/6/2025,Shepherd's Pie
-Maple Butter Tart,Teraanga Commons Dining Hall,,130,,F,F,F,T,,,,,,,,,,,10/6/2025,Tart
-Margherita Pizza,Teraanga Commons Dining Hall,,170,,F,F,F,T,,"tomato, fresh basil, mozzarella, ricotta",,,,,,,,,10/6/2025,Pizza (Vegetarian)
-Marinara Sauce (3000  millilitre),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,10/6/2025,Sauce
-Market Mixed Greens,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
-Marrakesh Vegetable Stew,Teraanga Commons Dining Hall,,120,,T,T,F,T,,"chickpeas, potato, zucchini, tomato, carrots",,,,,,,,,10/6/2025,Stew
-Meatball Sub,Teraanga Commons Dining Hall,,230,,F,F,F,F,,"meatballs, mozzarella, tomato basil sauce, pesto mayo",,,,,,,,,10/6/2025,Sandwich
-Mediterranean Kale Minestrone Soup (8000  millilitre),Teraanga Commons Dining Hall,,,,T,T,F,T,,"A twist on a classic Italian vegetable broth soup containing brown rice, white beans and kale.",,,,,,,,,10/6/2025,Soup
-Mint Fudge,Teraanga Commons Dining Hall,,220,,F,F,F,F,,,,,,,,,,,10/6/2025,Square
-Miso Broth (356  millilitre),Teraanga Commons Dining Hall,,80,,T,F,F,T,,,,,,,,,,,10/6/2025,Soup
-Mixed Berry Oat Bar,Teraanga Commons Dining Hall,,190,,T,T,F,T,,,,,,,,,,,10/6/2025,Oatmeal
-Moroccan Chickpea Soup (237  millilitre),Teraanga Commons Dining Hall,,120,,T,T,F,T,,"A flavourful tomato-based broth soup loaded with chickpeas, potatoes, carrots, spinach and warm spices.",,,,,,,,,10/6/2025,Soup
-MTO PTN SUNFLOWER SEEDS (30 ML),Teraanga Commons Dining Hall,,110,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
-Mushroom,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Mushroom
-Mushroom & Caramelized Onion Pizza,Teraanga Commons Dining Hall,,200,,F,F,F,F,,"mushroom, caramelized onion, parsley, alfredo base, mozzarella, parmesan",,,,,,,,,10/6/2025,Pizza (Vegetarian)
-No Gluten Fusilli,Teraanga Commons Dining Hall,,210,,T,T,F,T,,,,,,,,,,,10/6/2025,Pasta
-No Gluten Penne,Teraanga Commons Dining Hall,,160,,T,T,F,T,,,,,,,,,,,10/6/2025,Pasta
-No Gluten Turkey Noodle Soup (8  litre),Teraanga Commons Dining Hall,,,,F,T,F,F,,Home-style soup with pieces of turkey breast and no gluten fettuccine noodles.,,,,,,,,,10/6/2025,Soup
-Nori Seaweed,Teraanga Commons Dining Hall,,10,,T,T,F,T,,,,,,,,,,,10/6/2025,Seaweed
-Oatmeal Raisin Cookie,Teraanga Commons Dining Hall,,120,,F,F,F,T,,,,,,,,,,,10/6/2025,Cookie
-Onion,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,10/6/2025,Onion
-Onion Rings,Teraanga Commons Dining Hall,,180,,F,F,F,F,,,,,,,,,,,10/6/2025,Onion Rings
-Orange Cremcicle Cake,Teraanga Commons Dining Hall,,310,,F,F,F,F,,,,,,,,,,,10/6/2025,Cake
-Parmesan Cheese,Teraanga Commons Dining Hall,,10,,F,T,F,F,,,,,,,,,,,10/6/2025,Cheese
-Parsley Potatoes,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,10/6/2025,Potato
-Peameal Bacon,Teraanga Commons Dining Hall,,45,,F,T,F,F,,,,,,,,,,,10/6/2025,Bacon
-Pepperoni Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,F,,,,,,,,,,,10/6/2025,Pizza
-Pesto Sauce,Teraanga Commons Dining Hall,,420,,F,T,F,F,,,,,,,,,,,10/6/2025,Sauce
-Pita Chips,Teraanga Commons Dining Hall,,25,,T,F,F,T,,,,,,,,,,,10/6/2025,Chips
-Pita Chips (1  kilogram),Teraanga Commons Dining Hall,,,,T,F,F,T,,,,,,,,,,,10/6/2025,Chips
-Plain Pancake,Teraanga Commons Dining Hall,,150,,F,F,F,F,,,,,,,,,,,10/6/2025,Pancake
-Pork Souvlaki,Teraanga Commons Dining Hall,,190,,F,T,F,F,,,,,,,,,,,10/6/2025,Pork
-Potato Wedges,Teraanga Commons Dining Hall,,110,,F,F,F,F,,,,,,,,,,,10/6/2025,Fries
-Poutine,Teraanga Commons Dining Hall,,370,,F,F,F,F,,"cheddar cheese curds, french fries, gravy",,,,,,,,,10/6/2025,Poutine
-Pumpkin Seeds,Teraanga Commons Dining Hall,,80,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
-Quinoa,Teraanga Commons Dining Hall,,45,,T,T,F,T,,,,,,,,,,,10/6/2025,Quinoa
-Ramen Noodles,Teraanga Commons Dining Hall,,70,,F,F,F,T,,,,,,,,,,,10/6/2025,Ramen
-Red Onion,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,10/6/2025,Onion
-Red Potatoes,Teraanga Commons Dining Hall,,120,,T,T,F,T,,,,,,,,,,,10/6/2025,Potato
-Red Potatoes & Onions,Teraanga Commons Dining Hall,,160,,T,T,F,T,,,,,,,,,,,10/6/2025,Potato
-Rice Krispie Square,Teraanga Commons Dining Hall,,80,,F,F,F,F,,,,,,,,,,,10/6/2025,Square
-Rice Noodles,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,10/6/2025,Noodles
-Roasted Beets & Basil,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,10/6/2025,Beets
-Roasted Corn & Green Pepper,Teraanga Commons Dining Hall,,120,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
-Roasted Eggplant,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,10/6/2025,Eggplant
-Roasted Potatoes,Teraanga Commons Dining Hall,,130,,T,T,F,T,,,,,,,,,,,10/6/2025,Potato
-Rotini,Teraanga Commons Dining Hall,,200,,T,F,F,T,,,,,,,,,,,10/6/2025,Pasta
-Sadza Chicken Stew,Teraanga Commons Dining Hall,,160,,F,F,F,F,,"chicken, onion, tomato, green onion",,,,,,,,,10/6/2025,Stew
-Salsa (3  litre),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,10/6/2025,Sauce
+Broccoli,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,10/6/2025,Broccoli
+Blondie,Teraanga Commons Dining Hall,,310,,F,F,F,T,,,,,,,,,,,10/6/2025,Brownie
 Salted Caramel Brownie,Teraanga Commons Dining Hall,,230,,F,F,F,T,,,,,,,,,,,10/6/2025,Brownie
-Sausage Round,Teraanga Commons Dining Hall,,160,,F,F,F,F,,,,,,,,,,,10/6/2025,Sausage
-Sauteed Zucchini,Teraanga Commons Dining Hall,,40,,T,T,F,T,,,,,,,,,,,10/6/2025,Zucchini
-Seasoned Ground Beef,Teraanga Commons Dining Hall,,150,,F,T,F,F,,,,,,,,,,,10/6/2025,Beef
-Shoyu Pork Broth (26520  millilitre),Teraanga Commons Dining Hall,,120,,F,F,F,F,,,,,,,,,,,10/6/2025,Soup
-Smoked Meat Sandwich,Teraanga Commons Dining Hall,,390,,F,F,F,F,,,,,,,,,,,10/6/2025,Sandwich
-Smoked Turkey Sandwich,Teraanga Commons Dining Hall,,620,,F,F,F,F,,,,,,,,,,,10/6/2025,Sandwich
 S'mores Brownie,Teraanga Commons Dining Hall,,200,,F,F,F,F,,,,,,,,,,,10/6/2025,Brownie
-Sour Cream,Teraanga Commons Dining Hall,,15,,F,T,F,T,,,,,,,,,,,10/6/2025,Sour cream
-Spicy Chicken Noodle Bowl,Teraanga Commons Dining Hall,,160,,F,F,F,F,,"gochujang chicken, spicy cucumber, green onion, sesame seeds, kimchi, udon noodles",,,,,,,,,10/6/2025,Noodles
-Spring Mix,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
-"STEW, GOULASH, BEEF, POTATO, VEGETABLES RES",Teraanga Commons Dining Hall,,100,,F,T,F,F,,,,,,,,,,,10/6/2025,Stew
 Strawberry Brownie,Teraanga Commons Dining Hall,,290,,F,F,F,F,,,,,,,,,,,10/6/2025,Brownie
-Sugar Cookie,Teraanga Commons Dining Hall,,110,,F,F,F,T,,,,,,,,,,,10/6/2025,Cookie
-Superfood Salad (1000  gram),Teraanga Commons Dining Hall,,,,F,F,F,T,,"chickpeas, couscous, tomato, cucumber, red onion, kale, feta cheese, greek vinaigrette",,,,,,,,,10/6/2025,Green Salad
-Sweet Potato and Caramelized Onion Pizza,Teraanga Commons Dining Hall,,560,,F,F,F,T,,,,,,,,,,,10/6/2025,Pizza (Vegetarian)
-Thai Tofu Stir Fry,Teraanga Commons Dining Hall,,170,,T,T,F,T,,"tofu, onion, carrot, snow peas, green pepper, cabbage, sweet and spicy sauce, soy sauce, green onion",,,,,,,,,10/6/2025,Noodles
-Tofu,Teraanga Commons Dining Hall,,45,,T,T,F,T,,,,,,,,,,,10/6/2025,Tofu
-Tomato,Teraanga Commons Dining Hall,,10,,T,T,F,T,,,,,,,,,,,10/6/2025,Tomato
-Tomato Mozzarella Penne (1000  gram),Teraanga Commons Dining Hall,,,,F,F,F,F,,,,,,,,,,,10/6/2025,Pasta
-Tuna Salad (59  millilitre),Teraanga Commons Dining Hall,,90,,F,T,F,F,,,,,,,,,,,10/6/2025,Fish
-Tuna Salad (80  millilitre),Teraanga Commons Dining Hall,,100,,F,T,F,F,,,,,,,,,,,10/6/2025,Fish
-Turkey Breakfast Sausage,Teraanga Commons Dining Hall,,30,,F,F,F,F,,,,,,,,,,,10/6/2025,Sausage
-Vanilla Cupcake,Teraanga Commons Dining Hall,,310,,F,F,F,F,,,,,,,,,,,10/6/2025,Cupcake
+WOW Butter Chocolate Fudge,Teraanga Commons Dining Hall,,300,,T,T,F,T,,,,,,,,,,,10/6/2025,Brownie
+Black Forest Cake,Teraanga Commons Dining Hall,,190,,F,F,F,F,,,,,,,,,,,10/6/2025,Cake
+Caramel Coffee Cake,Teraanga Commons Dining Hall,,300,,F,F,F,F,,,,,,,,,,,10/6/2025,Cake
+Lemon Buttermilk Cake,Teraanga Commons Dining Hall,,140,,F,F,F,F,,,,,,,,,,,10/6/2025,Cake
+Orange Cremcicle Cake,Teraanga Commons Dining Hall,,310,,F,F,F,F,,,,,,,,,,,10/6/2025,Cake
 Vegan Marble Cake,Teraanga Commons Dining Hall,,210,,T,T,F,T,,,,,,,,,,,10/6/2025,Cake
 Vegan No Gluten Chocolate Cake,Teraanga Commons Dining Hall,,150,,T,T,F,T,,,,,,,,,,,10/6/2025,Cake
-Vegetable Medley,Teraanga Commons Dining Hall,,60,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
-Vegetable Provolone Wrap,Teraanga Commons Dining Hall,,260,,F,F,F,F,,"carrot, red onion, zucchini, bell pepper, lettuce, tomato, provolone cheese, basil  pesto mayo, tortilla",,,,,,,,,10/6/2025,Wrap (No protein)
+Carrot (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,10/6/2025,Carrot
+Curried Carrots,Teraanga Commons Dining Hall,,80,,T,T,F,T,,,,,,,,,,,10/6/2025,Carrot
+Parmesan Cheese,Teraanga Commons Dining Hall,,10,,F,T,F,F,,,,,,,,,,,10/6/2025,Cheese
+Baked Chicken Thighs,Teraanga Commons Dining Hall,,,,F,T,F,F,,,,,,,,,,,10/6/2025,Chicken
+Cajun Chicken Thigh,Teraanga Commons Dining Hall,,210,,F,F,F,F,,,,,,,,,,,10/6/2025,Chicken
+Five Spice Chicken (90  millilitre),Teraanga Commons Dining Hall,,180,,F,T,F,F,,,,,,,,,,,10/6/2025,Chicken
+Herb Roasted Chicken,Teraanga Commons Dining Hall,,170,,F,T,F,F,,,,,,,,,,,10/6/2025,Chicken
+Chickpeas,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,10/6/2025,Chickpeas
+Pita Chips,Teraanga Commons Dining Hall,,25,,T,F,F,T,,,,,,,,,,,10/6/2025,Chips
+Pita Chips (1  kilogram),Teraanga Commons Dining Hall,,,,T,F,F,T,,,,,,,,,,,10/6/2025,Chips
+Chicken & Corn Chowder,Teraanga Commons Dining Hall,,,,F,F,F,F,,"A creamy chowder loaded with chicken breast pieces, corn and potatoes.",,,,,,,,,10/6/2025,Chowder
+Apple Cabbage Slaw,Teraanga Commons Dining Hall,,60,,F,T,F,T,,,,,,,,,,,10/6/2025,Coleslaw
+Jalapeno Coleslaw (1000  gram),Teraanga Commons Dining Hall,,,,F,T,F,T,,"cabbage, carrot, jalapenos, creamy dressing",,,,,,,,,10/6/2025,Coleslaw
+Chocolate Chip Cookie,Teraanga Commons Dining Hall,,130,,F,F,F,T,,,,,,,,,,,10/6/2025,Cookie
+Double Chocolate Cookie,Teraanga Commons Dining Hall,,160,,F,F,F,T,,,,,,,,,,,10/6/2025,Cookie
+Lemon Cookie,Teraanga Commons Dining Hall,,70,,F,F,F,F,,,,,,,,,,,10/6/2025,Cookie
+Oatmeal Raisin Cookie,Teraanga Commons Dining Hall,,120,,F,F,F,T,,,,,,,,,,,10/6/2025,Cookie
+Sugar Cookie,Teraanga Commons Dining Hall,,110,,F,F,F,T,,,,,,,,,,,10/6/2025,Cookie
+Corn,Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,10/6/2025,Corn
+Dried Cranberries,Teraanga Commons Dining Hall,,25,,T,T,F,T,,,,,,,,,,,10/6/2025,Cranberry
+Cucumber,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Cucumber
+Vanilla Cupcake,Teraanga Commons Dining Hall,,310,,F,F,F,F,,,,,,,,,,,10/6/2025,Cupcake
+Chickpea Curry,Teraanga Commons Dining Hall,,150,,F,T,F,T,,,,,,,,,,,10/6/2025,Curry
+Cauliflower Bulgur Curry,Teraanga Commons Dining Hall,,160,,T,F,F,T,,"lentil, bulgur, cauliflower, red pepper, onion, coconut milk",,,,,,,,,10/6/2025,Curry (Vegetable)
+Hummus,Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,10/6/2025,Dip
+Creamy Scrambled Egg,Teraanga Commons Dining Hall,,170,,F,F,F,F,,,,,,,,,,,10/6/2025,Egg
+Egg (118  millilitre),Teraanga Commons Dining Hall,,180,,F,T,F,T,,,,,,,,,,,10/6/2025,Egg
+Egg White (118  millilitre),Teraanga Commons Dining Hall,,60,,F,T,F,T,,,,,,,,,,,10/6/2025,Egg
+Hard Cooked Egg (1  piece),Teraanga Commons Dining Hall,,60,,F,T,F,T,,,,,,,,,,,10/6/2025,Egg
+Roasted Eggplant,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,10/6/2025,Eggplant
+Falafel,Teraanga Commons Dining Hall,,210,,T,T,F,T,,,,,,,,,,,10/6/2025,Falafel
+Tuna Salad (59  millilitre),Teraanga Commons Dining Hall,,90,,F,T,F,F,,,,,,,,,,,10/6/2025,Fish
+Tuna Salad (80  millilitre),Teraanga Commons Dining Hall,,100,,F,T,F,F,,,,,,,,,,,10/6/2025,Fish
+Potato Wedges,Teraanga Commons Dining Hall,,110,,F,F,F,F,,,,,,,,,,,10/6/2025,French Fries
+Cajun-Style Dirty Rice,Teraanga Commons Dining Hall,,160,,T,T,F,T,,"black beans, onion, red pepper, celery, peas, spices, brown rice",,,,,,,,,10/6/2025,Fried Rice
+Garlic,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Garlic
+Chickpea Panzanella Ricotta Salad,Teraanga Commons Dining Hall,,340,,F,F,F,F,,"crispy pesto chickpeas, ricotta, kalamata olives, cucumber, tomato, celery, red pepper, capers, balsamic glaze",,,,,,,,,10/6/2025,Grain Salad
+Creamy Chickpea Salad (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,"chickpeas, celery, green onion, red pepper, italian parsley, tahini lemon garlic vinaigrette",,,,,,,,,10/6/2025,Grain Salad
+Kale Apple Chickpea Salad (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,"chickpeas, cauliflower, carrot, kale, red onion, apple, fresh parsley, maple dijon vinaigrette",,,,,,,,,10/6/2025,Grain Salad
+Fattoush Salad,Teraanga Commons Dining Hall,,60,,F,F,F,F,,"pita croutons, lettuce, cucumber, tomato, green pepper, red onion, lemon vinaigrette",,,,,,,,,10/6/2025,Green Salad
+Superfood Salad (1000  gram),Teraanga Commons Dining Hall,,,,F,F,F,T,,"chickpeas, couscous, tomato, cucumber, red onion, kale, feta cheese, greek vinaigrette",,,,,,,,,10/6/2025,Green Salad
+Grilled Ham,Teraanga Commons Dining Hall,,30,,F,T,F,F,,,,,,,,,,,10/6/2025,Ham
+Ham (3  slice),Teraanga Commons Dining Hall,,60,,F,T,F,F,,,,,,,,,,,10/6/2025,Ham
+Ham (59  millilitre),Teraanga Commons Dining Hall,,30,,F,T,F,F,,,,,,,,,,,10/6/2025,Ham
+Hash Brown,Teraanga Commons Dining Hall,,60,,F,F,F,F,,,,,,,,,,,10/6/2025,Hash Browns
+Baby Kale,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,10/6/2025,Kale
+Korean Lentils,Teraanga Commons Dining Hall,,,,T,F,F,T,,,,,,,,,,,10/6/2025,Lentils
+Mushroom,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Mushroom
+Chicken Pho,Teraanga Commons Dining Hall,,410,,F,F,F,F,,,,,,,,,,,10/6/2025,Noodles
+Hoisin Chow Mein Salad (59  millilitre),Teraanga Commons Dining Hall,,40,,F,F,F,T,,"chow mein noodles, napa cabbage, cucumber, carrot, daikon radish, red peppers, green onion, sesame seeds, hoisin ginger vinaigrette",,,,,,,,,10/6/2025,Noodles
+Rice Noodles,Teraanga Commons Dining Hall,,70,,T,T,F,T,,,,,,,,,,,10/6/2025,Noodles
+Spicy Chicken Noodle Bowl,Teraanga Commons Dining Hall,,160,,F,F,F,F,,"gochujang chicken, spicy cucumber, green onion, sesame seeds, kimchi, udon noodles",,,,,,,,,10/6/2025,Noodles
+Thai Tofu Stir Fry,Teraanga Commons Dining Hall,,170,,T,T,F,T,,"tofu, onion, carrot, snow peas, green pepper, cabbage, sweet and spicy sauce, soy sauce, green onion",,,,,,,,,10/6/2025,Noodles
 Veggie Pho (200  gram),Teraanga Commons Dining Hall,,130,,T,T,F,T,,"tofu, onion, mushroom, pho vegetable broth, rice noodles, cilantro, green onion",,,,,,,,,10/6/2025,Noodles
+Mixed Berry Oat Bar,Teraanga Commons Dining Hall,,190,,T,T,F,T,,,,,,,,,,,10/6/2025,Oatmeal
+Black Olives,Teraanga Commons Dining Hall,,25,,T,T,F,T,,,,,,,,,,,10/6/2025,Olive
+Green Onion,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Onion
+Onion,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,10/6/2025,Onion
+Red Onion,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,10/6/2025,Onion
+Onion Rings,Teraanga Commons Dining Hall,,180,,F,F,F,F,,,,,,,,,,,10/6/2025,Onion Rings
+Plain Pancake,Teraanga Commons Dining Hall,,150,,F,F,F,F,,,,,,,,,,,10/6/2025,Pancake
+Chicken Bruschetta Penne Alfredo,Teraanga Commons Dining Hall,,230,,F,F,F,F,,"chicken breast, tomato, basil, parmesan, alfredo sauce, penne",,,,,,,,,10/6/2025,Pasta
+Farfalle,Teraanga Commons Dining Hall,,200,,T,F,F,T,,,,,,,,,,,10/6/2025,Pasta
+Kale Squash Gnocchi,Teraanga Commons Dining Hall,,320,,T,F,F,T,,"butternut squash, kale, sage, gnocchi",,,,,,,,,10/6/2025,Pasta
+No Gluten Fusilli,Teraanga Commons Dining Hall,,210,,T,T,F,T,,,,,,,,,,,10/6/2025,Pasta
+No Gluten Penne,Teraanga Commons Dining Hall,,160,,T,T,F,T,,,,,,,,,,,10/6/2025,Pasta
+Rotini,Teraanga Commons Dining Hall,,200,,T,F,F,T,,,,,,,,,,,10/6/2025,Pasta
+Tomato Mozzarella Penne (1000  gram),Teraanga Commons Dining Hall,,,,F,F,F,F,,,,,,,,,,,10/6/2025,Pasta
+Asian Noodle Salad (1000  gram),Teraanga Commons Dining Hall,,,,F,F,F,T,,"rice noodles, snow peas, broccoli, cucumber, carrot, onion, sesame seeds, spicy asian vinaigrette",,,,,,,,,10/6/2025,Pasta Salad
+Green Peas,Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,10/6/2025,Peas
+Green Pepper,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Pepper
+Dill Pickles,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Pickles
+Bacon Cheeseburger Pizza,Teraanga Commons Dining Hall,,210,,F,F,F,F,,"ground beef, bacon, red onion, mozzarella, 3 cheese blend",,,,,,,,,10/6/2025,Pizza
+BBQ Tofu Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,T,,"tofu, red onion, cilantro, BBQ tomato base, mozzarella",,,,,,,,,10/6/2025,Pizza
+Buffalo Chicken Pizza,Teraanga Commons Dining Hall,,180,,F,F,F,F,,"spicy buffalo chicken, red onion, buffalo sauce, mozzarella, blue cheese",,,,,,,,,10/6/2025,Pizza
+Canadian Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,F,,"pepperoni, bacon, mushroom, mozzarella",,,,,,,,,10/6/2025,Pizza
+Hawaiian Pizza,Teraanga Commons Dining Hall,,170,,F,F,F,F,,"ham, pineapple, mozzarella",,,,,,,,,10/6/2025,Pizza
+Jalapeno Popper Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,F,,"cream cheese, jalapeno peppers, red onions, monterey jack, bacon",,,,,,,,,10/6/2025,Pizza
+Pepperoni Pizza,Teraanga Commons Dining Hall,,190,,F,F,F,F,,,,,,,,,,,10/6/2025,Pizza
+Cheese Pizza,Teraanga Commons Dining Hall,,150,,F,F,F,T,,,,,,,,,,,10/6/2025,Pizza (Cheese)
+Grilled Eggplant Pizza,Teraanga Commons Dining Hall,,180,,F,F,F,T,,"grilled eggplant, black olives, basil, chili pepper flakes, mozzarella",,,,,,,,,10/6/2025,Pizza (Vegetarian)
+Margherita Pizza,Teraanga Commons Dining Hall,,170,,F,F,F,T,,"tomato, fresh basil, mozzarella, ricotta",,,,,,,,,10/6/2025,Pizza (Vegetarian)
+Mushroom & Caramelized Onion Pizza,Teraanga Commons Dining Hall,,200,,F,F,F,F,,"mushroom, caramelized onion, parsley, alfredo base, mozzarella, parmesan",,,,,,,,,10/6/2025,Pizza (Vegetarian)
+Sweet Potato and Caramelized Onion Pizza,Teraanga Commons Dining Hall,,560,,F,F,F,T,,,,,,,,,,,10/6/2025,Pizza (Vegetarian)
+Chasu Pork Loin (1  slice),Teraanga Commons Dining Hall,,70,,F,F,F,F,,,,,,,,,,,10/6/2025,Pork
+Pork Souvlaki,Teraanga Commons Dining Hall,,190,,F,T,F,F,,,,,,,,,,,10/6/2025,Pork
+Home Fried Potatoes,Teraanga Commons Dining Hall,,180,,F,F,F,F,,,,,,,,,,,10/6/2025,Potato
+Home Style Potatoes,Teraanga Commons Dining Hall,,90,,F,F,F,F,,,,,,,,,,,10/6/2025,Potato
+Parsley Potatoes,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,10/6/2025,Potato
+Red Potatoes,Teraanga Commons Dining Hall,,120,,T,T,F,T,,,,,,,,,,,10/6/2025,Potato
+Red Potatoes & Onions,Teraanga Commons Dining Hall,,160,,T,T,F,T,,,,,,,,,,,10/6/2025,Potato
+Roasted Potatoes,Teraanga Commons Dining Hall,,130,,T,T,F,T,,,,,,,,,,,10/6/2025,Potato
+Buffalo Ranch Potato Salad (1000  gram),Teraanga Commons Dining Hall,,140,,F,T,F,F,,"red potatoes, red pepper, celery, green onion, buffalo ranch dressing",,,,,,,,,10/6/2025,Potato Salad
+Grainy Dijon Potato Salad (1000  gram),Teraanga Commons Dining Hall,,,,T,T,F,T,,"mini red potatoes, mustard vinaigrette ",,,,,,,,,10/6/2025,Potato Salad
+Poutine,Teraanga Commons Dining Hall,,370,,F,F,F,F,,"cheddar cheese curds, french fries, gravy",,,,,,,,,10/6/2025,Poutine
+Beef Quesadilla,Teraanga Commons Dining Hall,,280,,F,F,F,F,,"taco-spiced ground beef, cheddar cheese, tortilla",,,,,,,,,10/6/2025,Quesadilla
+Quinoa,Teraanga Commons Dining Hall,,45,,T,T,F,T,,,,,,,,,,,10/6/2025,Quinoa
+Ramen Noodles,Teraanga Commons Dining Hall,,70,,F,F,F,T,,,,,,,,,,,10/6/2025,Ramen
+Aromatic Basmati Rice,Teraanga Commons Dining Hall,,120,,T,T,F,T,,,,,,,,,,,10/6/2025,Rice
+Coconut Jasmine Rice,Teraanga Commons Dining Hall,,190,,T,T,F,T,,,,,,,,,,,10/6/2025,Rice
 White Rice,Teraanga Commons Dining Hall,,130,,T,T,F,T,,,,,,,,,,,10/6/2025,Rice
-WOW Butter Chocolate Fudge,Teraanga Commons Dining Hall,,300,,T,T,F,T,,,,,,,,,,,10/6/2025,Brownie
+Club Sandwich,Teraanga Commons Dining Hall,,250,,F,F,F,F,,"bacon, ham, turkey, lettuce, tomato, cheddar cheese, mayo, whole wheat bread",,,,,,,,,10/6/2025,Sandwich
+Egg Salad Baguette,Teraanga Commons Dining Hall,,200,,F,F,F,T,,"egg salad, lettuce, baguette",,,,,,,,,10/6/2025,Sandwich
+Hot Beef Sandwich,Teraanga Commons Dining Hall,,400,,F,F,F,F,,"roast beef, onion, mushroom,  gravy, bun",,,,,,,,,10/6/2025,Sandwich
+Meatball Sub,Teraanga Commons Dining Hall,,230,,F,F,F,F,,"meatballs, mozzarella, tomato basil sauce, pesto mayo",,,,,,,,,10/6/2025,Sandwich
+Smoked Meat Sandwich,Teraanga Commons Dining Hall,,390,,F,F,F,F,,,,,,,,,,,10/6/2025,Sandwich
+Smoked Turkey Sandwich,Teraanga Commons Dining Hall,,620,,F,F,F,F,,,,,,,,,,,10/6/2025,Sandwich
+Goat Cheese & Vegetable Baguette,Teraanga Commons Dining Hall,,250,,F,F,F,F,,"mushroom, caramelized onion, spinach, zucchini, sundried tomato goat cheese",,,,,,,,,10/6/2025,Sandwich (No protein)
+Alfredo Sauce (3000  millilitre),Teraanga Commons Dining Hall,,,,F,T,F,F,,,,,,,,,,,10/6/2025,Sauce
+Balsamic Glaze,Teraanga Commons Dining Hall,,35,,T,T,F,T,,,,,,,,,,,10/6/2025,Sauce
+Lemon Garlic Vinaigrette,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,10/6/2025,Sauce
+Marinara Sauce (3000  millilitre),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,10/6/2025,Sauce
+Pesto Sauce,Teraanga Commons Dining Hall,,420,,F,T,F,F,,,,,,,,,,,10/6/2025,Sauce
+Salsa (3  litre),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,10/6/2025,Sauce
+Sausage Round,Teraanga Commons Dining Hall,,160,,F,F,F,F,,,,,,,,,,,10/6/2025,Sausage
+Turkey Breakfast Sausage,Teraanga Commons Dining Hall,,30,,F,F,F,F,,,,,,,,,,,10/6/2025,Sausage
+Nori Seaweed,Teraanga Commons Dining Hall,,10,,T,T,F,T,,,,,,,,,,,10/6/2025,Seaweed
+Lentil Shepherd's Pie,Teraanga Commons Dining Hall,,150,,T,F,F,T,,"lentils, carrot, celery, gravy, spices, mashed potato",,,,,,,,,10/6/2025,Shepherd's Pie
+Chickpea & Root Vegetable Soup (8000  millilitre),Teraanga Commons Dining Hall,,50,,T,T,F,T,,,,,,,,,,,10/6/2025,Soup
+Coconut Curry Chickpea Soup (474  millilitre),Teraanga Commons Dining Hall,,480,,T,T,F,T,,"Chickpeas, lentils and sweet potatoes simmered in coconut, ginger, turmeric and cinnamon flavours.",,,,,,,,,10/6/2025,Soup
+Corn Lentil Soup (8000  millilitre),Teraanga Commons Dining Hall,,,,T,T,F,T,,,,,,,,,,,10/6/2025,Soup
+Cream of spinach soup,Teraanga Commons Dining Hall,,,,F,F,F,F,,,,,,,,,,,10/6/2025,Soup
+GF Broccoli Cheddar Soup,Teraanga Commons Dining Hall,,,,F,F,F,F,,A thick and delicious cheese soup with onions and broccoli florets.,,,,,,,,,10/6/2025,Soup
+Mediterranean Kale Minestrone Soup (8000  millilitre),Teraanga Commons Dining Hall,,,,T,T,F,T,,"A twist on a classic Italian vegetable broth soup containing brown rice, white beans and kale.",,,,,,,,,10/6/2025,Soup
+Miso Broth (356  millilitre),Teraanga Commons Dining Hall,,80,,T,F,F,T,,,,,,,,,,,10/6/2025,Soup
+Moroccan Chickpea Soup (237  millilitre),Teraanga Commons Dining Hall,,120,,T,T,F,T,,"A flavourful tomato-based broth soup loaded with chickpeas, potatoes, carrots, spinach and warm spices.",,,,,,,,,10/6/2025,Soup
+No Gluten Turkey Noodle Soup (8  litre),Teraanga Commons Dining Hall,,,,F,T,F,F,,Home-style soup with pieces of turkey breast and no gluten fettuccine noodles.,,,,,,,,,10/6/2025,Soup
+Shoyu Pork Broth (26520  millilitre),Teraanga Commons Dining Hall,,120,,F,F,F,F,,,,,,,,,,,10/6/2025,Soup
+Sour Cream,Teraanga Commons Dining Hall,,15,,F,T,F,T,,,,,,,,,,,10/6/2025,Sour cream
+Chocolate Chip Rice Krispie Square,Teraanga Commons Dining Hall,,100,,F,F,F,F,,,,,,,,,,,10/6/2025,Square
+Confetti Rice Krispie Square,Teraanga Commons Dining Hall,,90,,F,F,F,F,,,,,,,,,,,10/6/2025,Square
+Mint Fudge,Teraanga Commons Dining Hall,,220,,F,F,F,F,,,,,,,,,,,10/6/2025,Square
+Rice Krispie Square,Teraanga Commons Dining Hall,,80,,F,F,F,F,,,,,,,,,,,10/6/2025,Square
+Bean Ragout,Teraanga Commons Dining Hall,,130,,T,T,F,T,,"kidney beans, chickpeas, onion, green pepper, carrot, tomato",,,,,,,,,10/6/2025,Stew
+Braised Beef Ragu (3000  millilitre),Teraanga Commons Dining Hall,,160,,F,T,F,F,,,,,,,,,,,10/6/2025,Stew
+Marrakesh Vegetable Stew,Teraanga Commons Dining Hall,,120,,T,T,F,T,,"chickpeas, potato, zucchini, tomato, carrots",,,,,,,,,10/6/2025,Stew
+Sadza Chicken Stew,Teraanga Commons Dining Hall,,160,,F,F,F,F,,"chicken, onion, tomato, green onion",,,,,,,,,10/6/2025,Stew
+"STEW, GOULASH, BEEF, POTATO, VEGETABLES RES",Teraanga Commons Dining Hall,,100,,F,T,F,F,,,,,,,,,,,10/6/2025,Stew
+Chili Garlic Veggie Stir Fry,Teraanga Commons Dining Hall,,90,,T,F,F,T,,"cabbage, carrot, celery, onion, spices, sweet chili sauce, soy sauce",,,,,,,,,10/6/2025,Stir Fry
+Chicken Tinga Taco,Teraanga Commons Dining Hall,,240,,F,F,F,F,,"chicken tinga, lettuce, tomato, sour cream, cheddar cheese, tortilla",,,,,,,,,10/6/2025,Taco
+Blueberry Tart,Teraanga Commons Dining Hall,,120,,F,F,F,F,,,,,,,,,,,10/6/2025,Tart
+Maple Butter Tart,Teraanga Commons Dining Hall,,130,,F,F,F,T,,,,,,,,,,,10/6/2025,Tart
+French Toast,Teraanga Commons Dining Hall,,120,,F,F,F,T,,,,,,,,,,,10/6/2025,Toast
+Asian Tofu (59  millilitre),Teraanga Commons Dining Hall,,45,,T,F,F,T,,,,,,,,,,,10/6/2025,Tofu
+Kung Pao Tofu,Teraanga Commons Dining Hall,,150,,T,F,F,T,,,,,,,,,,,10/6/2025,Tofu
+Tofu,Teraanga Commons Dining Hall,,45,,T,T,F,T,,,,,,,,,,,10/6/2025,Tofu
+Tomato,Teraanga Commons Dining Hall,,10,,T,T,F,T,,,,,,,,,,,10/6/2025,Tomato
+Bok Choy,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
+Ginger Roasted Cauliflower & Carrots,Teraanga Commons Dining Hall,,100,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
+Market Mixed Greens,Teraanga Commons Dining Hall,,5,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
+MTO PTN SUNFLOWER SEEDS (30 ML),Teraanga Commons Dining Hall,,110,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
+Pumpkin Seeds,Teraanga Commons Dining Hall,,80,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
+Roasted Corn & Green Pepper,Teraanga Commons Dining Hall,,120,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
+Spring Mix,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
+Vegetable Medley,Teraanga Commons Dining Hall,,60,,T,T,F,T,,,,,,,,,,,10/6/2025,Vegetables
+Chickpea Shawarma Wrap,Teraanga Commons Dining Hall,,240,,T,F,F,T,,"smashed lemon tahini chickpeas, pickled red cabbage, cucumber, carrots, lettuce, garlic sauce, tortilla",,,,,,,,,10/6/2025,Wrap
+Korean BBQ Tempeh Wrap,Teraanga Commons Dining Hall,,280,,T,F,F,T,,"korean BBQ tempeh, red pepper, green onion, guacamole, lettuce, sesame seeds, tortilla",,,,,,,,,10/6/2025,Wrap
+Cauliflower Lentil Wrap,Teraanga Commons Dining Hall,,260,,T,F,F,T,,"cauliflower & red lentil curry, basmati rice, tortilla",,,,,,,,,10/6/2025,Wrap (No protein)
+Grilled Vegetable Wrap,Teraanga Commons Dining Hall,,200,,F,F,F,F,,"grilled zucchini, roasted red pepper, spinach, sundried tomato pesto, tortilla",,,,,,,,,10/6/2025,Wrap (No protein)
+Vegetable Provolone Wrap,Teraanga Commons Dining Hall,,260,,F,F,F,F,,"carrot, red onion, zucchini, bell pepper, lettuce, tomato, provolone cheese, basil  pesto mayo, tortilla",,,,,,,,,10/6/2025,Wrap (No protein)
+Sauteed Zucchini,Teraanga Commons Dining Hall,,40,,T,T,F,T,,,,,,,,,,,10/6/2025,Zucchini
 Zucchini,Teraanga Commons Dining Hall,,0,,T,T,F,T,,,,,,,,,,,10/6/2025,Zucchini

--- a/backend/automated_data_collection/roostersFoodInfo.csv
+++ b/backend/automated_data_collection/roostersFoodInfo.csv
@@ -24,6 +24,6 @@ Bacon Pita,Rooster's,11.99,,,,,,,,A generous porion of bacon in a pita with your
 M. Tofu Pita,Rooster's,9.99,,,,,,,,Firm tofu grilled on our vegitarian grill with your choice of toppings. ,,,,,,,,,10/30/2025,Pita with protein
 Falafel Pita,Rooster's,9.99,,,,,,,,A deliciously spiced falafel  and served with your choice of toppings.,,,,,,,,,10/30/2025,Pita with protein
 Gyro Pita,Rooster's,10.89,,,,,,,,Greek style seasoned lamb and beef served with your choice of toppings.,,,,,,,,,10/30/2025,Pita with protein
-Veggie Patty,Rooster's,10.99,,,,,,,,"Half a soy based vegitarian patty, wonderfully seasoned with your choice of toppings.",,,,,,,,,10/30/2025,Burger
+Veggie Patty,Rooster's,10.99,,,,,,,,"Half a soy based vegitarian patty, wonderfully seasoned with your choice of toppings.",,,,,,,,,10/30/2025,Hamburger
 Ham Pita,Rooster's,10.69,,,,,,,,Thin sliced deli fresh black forest ham served hot or cold with your choice of toppings.,,,,,,,,,10/30/2025,Pita with protein
 Pita Dippers,Rooster's,6.09,,,,,,,,"A generous helping of pita pieces, with two dipping sauces and two veggies of your choice.",,,,,,,,,10/30/2025,Chips

--- a/backend/models/food_category.py
+++ b/backend/models/food_category.py
@@ -109,6 +109,6 @@ class FoodCategory(db.Model):
     @classmethod
     def get_by_name(cls, category_name):
         """
-        Retrieve a FoodCategory by name
+        Retrieve a FoodCategory by name (case insensitive)
         """
-        return db.session.get(cls, category_name)
+        return cls.query.filter(cls.category_name.ilike(category_name)).first()

--- a/backend/tests/test_real_browse_endpoints.py
+++ b/backend/tests/test_real_browse_endpoints.py
@@ -1,0 +1,33 @@
+import requests
+
+# Test script that queries each of the real food-item endpoints
+# Instructions:
+#   1. Start the backend server
+#   2. In a new terminal navigate to this directory
+#   3. Run the test: python test_real_browse_endpoints.py
+
+BASE_URL = "http://127.0.0.1:5000/browse/food-item"
+MAX_ITEMS = 660  # Change this to match the total number of food items
+bad_items = []  # Keep track of problematic item ids
+
+print(f"Querying {MAX_ITEMS} endpoints. Please wait...")
+
+for item_id in range(1, MAX_ITEMS + 1):
+    url = f"{BASE_URL}/{item_id}"
+
+    try:
+        response = requests.get(url, timeout=2)
+
+        if response.status_code != 200:
+            print(f"Item {item_id} failed with status code {response.status_code}")
+            bad_items.append(item_id)
+
+    except requests.exceptions.RequestException as e:
+        print(f"Item {item_id} request error: {e}")
+        bad_items.append(item_id)
+
+# Output the final result
+if len(bad_items) == 0:
+    print(f"PASS: All item_ids from 1 to {MAX_ITEMS} returned HTTP 200")
+else:
+    print(f"FAIL: The following item_ids failed: {bad_items}")

--- a/backend/tests/test_real_browse_endpoints.py
+++ b/backend/tests/test_real_browse_endpoints.py
@@ -5,29 +5,38 @@ import requests
 #   1. Start the backend server
 #   2. In a new terminal navigate to this directory
 #   3. Run the test: python test_real_browse_endpoints.py
+#
+#   Note: Sometimes item_id 1 will timeout. Do not worry about it.
 
 BASE_URL = "http://127.0.0.1:5000/browse/food-item"
 MAX_ITEMS = 660  # Change this to match the total number of food items
-bad_items = []  # Keep track of problematic item ids
 
-print(f"Querying {MAX_ITEMS} endpoints. Please wait...")
 
-for item_id in range(1, MAX_ITEMS + 1):
-    url = f"{BASE_URL}/{item_id}"
+def main():
+    bad_items = []  # Keep track of problematic item ids
 
-    try:
-        response = requests.get(url, timeout=2)
+    print(f"Querying {MAX_ITEMS} endpoints. Please wait...")
 
-        if response.status_code != 200:
-            print(f"Item {item_id} failed with status code {response.status_code}")
+    for item_id in range(1, MAX_ITEMS + 1):
+        url = f"{BASE_URL}/{item_id}"
+
+        try:
+            response = requests.get(url, timeout=2)
+
+            if response.status_code != 200:
+                print(f"Item {item_id} failed with status code {response.status_code}")
+                bad_items.append(item_id)
+
+        except requests.exceptions.RequestException as e:
+            print(f"Item {item_id} request error: {e}")
             bad_items.append(item_id)
 
-    except requests.exceptions.RequestException as e:
-        print(f"Item {item_id} request error: {e}")
-        bad_items.append(item_id)
+    # Output the final result
+    if len(bad_items) == 0:
+        print(f"PASS: All item_ids from 1 to {MAX_ITEMS} returned HTTP 200")
+    else:
+        print(f"FAIL: The following item_ids failed: {bad_items}")
 
-# Output the final result
-if len(bad_items) == 0:
-    print(f"PASS: All item_ids from 1 to {MAX_ITEMS} returned HTTP 200")
-else:
-    print(f"FAIL: The following item_ids failed: {bad_items}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Bug fixes and added test coverage.

Fixes # (issue)
- Fixed category mismatches that caused the frontend to show no information for certain food items
- Added a little test-browsing script that checks the live endpoints

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Manual tests
- [x] Linted/formatted

Manual Tests:
1. Setup the backend (to ensure init_food_db runs)
        cd backend
        python -m venv backenv
        backenv\Scripts\activate
        pip install -r requirements.txt
        cd ..
        python -m backend.database.init_user_settings_db
        python -m backend.database.init_auth_db
        python -m backend.database.init_food_db
        python -m backend.database.init_logging_db
        python -m backend.app
2. Open the frontend
3. Go to enter food manually
4. Look for "Veggie Patty" and click on item id 640
5. You should see some information (not all blank)
6. In a new terminal navigate to backend/tests
7. Run 'python test_real_browse_endpoints.py'
8. The result should be PASS (or if there is a fail, it should only be item_id 1 that failed on account of a timeout)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
