### PR TITLE
Feature/password change

### DIFF
--- a/ENDPOINTS_SUMMARY.md
+++ b/ENDPOINTS_SUMMARY.md
@@ -6,8 +6,7 @@ Summary of endpoints.
 
 - [CU-Bytes Endpoints Summary](#cu-bytes-endpoints-summary)
   - [Table Of Contents](#table-of-contents)
-    - [Login](#login)
-    - [Register](#register)
+    - [Authentication](#authentication)
     - [Browse](#browse)
     - [Logging](#logging)
     - [Profiles](#profiles)
@@ -15,7 +14,7 @@ Summary of endpoints.
     - [ML Prediction](#ml-prediction)
 
 
-### Login
+### Authentication
 
     """
     POST /auth/login
@@ -31,7 +30,6 @@ Summary of endpoints.
     400 Bad Request - Wrong username or password
     """
 
-### Register
 
     """
     POST /auth/register
@@ -52,6 +50,26 @@ Summary of endpoints.
     201 Creation Success - User registered successfully
     400 Bad Request - Missing or invalid data
     409 Conflict - Username already exists
+    """
+
+    """
+    POST /auth/change-pw
+
+    Request Body (JSON):
+    {
+        "username": "string",       # required
+        "old_password": "string"    # required
+        "new_password": "string"    # required
+    }
+
+    Restrictions:
+    The password will only be changed if the old password is correct.
+    New passwords must be between 10 and 120 characters, with at least
+    one special character, one number, one uppercase and one lowercase
+
+    Responses:
+    201 Success - Password changed successfully
+    400 Bad Request - Missing or invalid data
     """
 
 ### Browse

--- a/backend/endpoints/authentication_endpoints.py
+++ b/backend/endpoints/authentication_endpoints.py
@@ -1,5 +1,9 @@
 from flask import Blueprint, request
-from backend.services.authentication_service import login_user_json, register_user_json
+from backend.services.authentication_service import (
+    login_user_json,
+    register_user_json,
+    change_password_json,
+)
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -47,3 +51,28 @@ def register():
     """
     data = request.json
     return register_user_json(data)
+
+
+@auth_bp.route("/change-pw", methods=["POST"])
+def change_password():
+    """
+    POST /auth/change-pw
+
+    Request Body (JSON):
+    {
+        "username": "string",       # required
+        "old_password": "string"    # required
+        "new_password": "string"    # required
+    }
+
+    Restrictions:
+    The password will only be changed if the old password is correct.
+    New passwords must be between 10 and 120 characters, with at least
+    one special character, one number, one uppercase and one lowercase
+
+    Responses:
+    201 Success - Password changed successfully
+    400 Bad Request - Missing or invalid data
+    """
+    data = request.json
+    return change_password_json(data)

--- a/backend/models/users_auth.py
+++ b/backend/models/users_auth.py
@@ -45,3 +45,9 @@ class UsersAuth(db.Model):
         except Exception:
             # Includes VerifyMismatchError which triggers on wrong password
             return False
+
+    def edit_password(self, new_password):
+        """Change the user's password"""
+        self.password = ph.hash(new_password)
+        db.session.add(self)
+        db.session.commit()

--- a/backend/services/authentication_service.py
+++ b/backend/services/authentication_service.py
@@ -21,7 +21,7 @@ def login_user_json(data):
     # attackers
 
     # Check missing fields
-    if len(username) == 0 or len(password) == 0:
+    if username is None or len(username) == 0 or password is None or len(password) == 0:
         return (
             jsonify({"status": "error", "message": "Invalid password or username."}),
             400,
@@ -75,7 +75,7 @@ def register_user_json(data):
     )
 
     # Check missing fields
-    if len(username) == 0 or len(password) == 0:
+    if username is None or len(username) == 0 or password is None or len(password) == 0:
         print("AuthenticationService: Username and password are required")
         return (
             jsonify(
@@ -223,7 +223,14 @@ def change_password_json(data):
     )
 
     # Check missing fields
-    if len(username) == 0 or len(old_password) == 0 or len(new_password) == 0:
+    if (
+        username is None
+        or len(username) == 0
+        or old_password is None
+        or len(old_password) == 0
+        or new_password is None
+        or len(new_password) == 0
+    ):
         print(
             "AuthenticationService: Username, old password, and new "
             "password are required"

--- a/backend/services/authentication_service.py
+++ b/backend/services/authentication_service.py
@@ -207,6 +207,141 @@ def register_user_json(data):
     )
 
 
+def change_password_json(data):
+    """
+    Attempt to change the password of an existing user.
+
+    Passwords must be between 10 and 120 characters, with at least one
+    special character, one number, one uppercase and one lowercase
+    """
+    username = data.get("username")
+    old_password = data.get("old_password")
+    new_password = data.get("new_password")
+    print(
+        f"AuthenticationService: Attempting to change user {username}'s "
+        f"password to {new_password}"
+    )
+
+    # Check missing fields
+    if len(username) == 0 or len(old_password) == 0 or len(new_password) == 0:
+        print(
+            "AuthenticationService: Username, old password, and new "
+            "password are required"
+        )
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": "Username, old password and new password required.",
+                }
+            ),
+            400,
+        )
+
+    # Authenticate the user using their old password
+    current_user = UsersAuth.get_user_by_name(username=username)
+    if current_user is None:
+        print("AuthenticationService: Username not found.")
+        return (
+            jsonify({"status": "error", "message": "This user does not exist."}),
+            400,
+        )
+
+    if not current_user.verify_password(old_password):
+        print("AuthenticationService: Old password does not match.")
+        return (
+            jsonify({"status": "error", "message": "Old password does not match."}),
+            400,
+        )
+
+    # Validate new password
+    if not len(new_password) >= 10 and len(new_password) <= 120:
+        print("AuthenticationService: Invalid new password format (length).")
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": (
+                        "Invalid password format. Password must be between 10 "
+                        "and 120 characters."
+                    ),
+                }
+            ),
+            400,
+        )
+
+    if not re.search(r'[!@#$%^&*()_\-+=\[\]{}\\|:;"\'<>,.?/]', new_password):
+        print("AuthenticationService: Invalid new password format (missing char).")
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": (
+                        "Invalid password format. Password must contain at "
+                        "least one special character."
+                    ),
+                }
+            ),
+            400,
+        )
+
+    if not re.search(r"[0-9]", new_password):
+        print("AuthenticationService: Invalid new password format (missing num).")
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": (
+                        "Invalid password format. Password must contain at "
+                        "least one numeric character."
+                    ),
+                }
+            ),
+            400,
+        )
+
+    if not re.search(r"[A-Z]", new_password):
+        print("AuthenticationService: Invalid new password format (missing cap).")
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": (
+                        "Invalid password format. Password must contain at "
+                        "least one uppercase character."
+                    ),
+                }
+            ),
+            400,
+        )
+
+    if not re.search(r"[a-z]", new_password):
+        print("AuthenticationService: Invalid new password format (missing low).")
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": (
+                        "Invalid password format. Password must contain at "
+                        "least one lowercase character."
+                    ),
+                }
+            ),
+            400,
+        )
+
+    current_user.edit_password(new_password)
+
+    print("AuthenticationService: User changed password successfully.")
+
+    return (
+        jsonify(
+            {"status": "success", "message": "User password changed successfully."}
+        ),
+        201,
+    )
+
+
 """
 Helper methods
 """

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,6 +1,6 @@
 # Project imports
 from backend.models.users_auth import UsersAuth
-from backend.tests.test_helpers import add_test_user
+from backend.tests.test_helpers import add_test_user, seeded_users
 
 # Arguments like client and app are automatically injected from conftest.py
 
@@ -268,6 +268,212 @@ def test_login_success(client, app):
     # Try again
     response = client.post(
         "/auth/login", json={"username": "Ellen", "password": "Password123!"}
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert data["status"] == "success"
+    assert "User logged in successfully." in data["message"]
+
+
+# ------------------------------------
+# Testing Changing Password
+# ------------------------------------
+def test_change_pw_missing_fields(client, seeded_users):
+    # Test missing username
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "",
+            "old_password": "1234",
+            "new_password": "Password123!",
+        },
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "Username, old password and new password required." in data["message"]
+
+    # Test missing old password
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "Alice",
+            "new_password": "Password123!",
+        },
+    )
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "Username, old password and new password required." in data["message"]
+
+    # Test missing new password
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "Alice",
+            "old_password": "Password123!",
+        },
+    )
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "Username, old password and new password required." in data["message"]
+
+
+def test_change_pw_username_invalid(client, seeded_users):
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "helloworld",
+            "old_password": "Password123!",
+            "new_password": "HelloWorld123!@#&",
+        },
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "user does not exist" in data["message"]
+
+
+def test_change_pw_wrong_password(client, seeded_users):
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "Alice",
+            "old_password": "Password1234!",
+            "new_password": "HelloWorld123!@#&",
+        },
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "password does not match" in data["message"]
+
+
+def test_change_pw_invalid_new_password(client, seeded_users):
+    # Try password too short
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "Alice",
+            "old_password": "Password123!",
+            "new_password": "Bp1!",
+        },
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "Password must be between 10 and 120 characters." in data["message"]
+
+    # Try password missing special character
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "Alice",
+            "old_password": "Password123!",
+            "new_password": "BestPassword789",
+        },
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "Password must contain at least one special character." in data["message"]
+
+    # Try password missing numberic character
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "Alice",
+            "old_password": "Password123!",
+            "new_password": "BestPassword?!#",
+        },
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "Password must contain at least one numeric character." in data["message"]
+
+    # Try password missing uppercase
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "Alice",
+            "old_password": "Password123!",
+            "new_password": "bestpassword789?!#",
+        },
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "Password must contain at least one uppercase character." in data["message"]
+
+    # Try password missing lowercase
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "Alice",
+            "old_password": "Password123!",
+            "new_password": "BESTPASSWORD789?!#",
+        },
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "Password must contain at least one lowercase character." in data["message"]
+
+
+def test_change_pw_valid(client, seeded_users):
+    # Sucessfully change the password
+    response = client.post(
+        "/auth/change-pw",
+        json={
+            "username": "Alice",
+            "old_password": "Password123!",
+            "new_password": "HelloWorld123!@#&",
+        },
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 201
+    assert "password changed successfully" in data["message"]
+
+    # Try logging in with the old password
+    response = client.post(
+        "/auth/login",
+        json={"username": "Alice", "password": "Password123!"},
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert data["status"] == "error"
+    assert "Invalid password or username." in data["message"]
+
+    # Try logging in with the new password
+    response = client.post(
+        "/auth/login",
+        json={"username": "Alice", "password": "HelloWorld123!@#&"},
     )
 
     data = response.get_json()


### PR DESCRIPTION
# Description

Add an endpoint that allows users to change their password. In order to authenticate the user, the user must also include their old password.

Fixes # (issue)
#121

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Manual tests
- [x] Linted/formatted

1. Start the backend
2. Start the fronted
3. Open the command prompt and change the password for Alice: curl -X POST http://127.0.0.1:5000/auth/change-pw -H "Content-Type: application/json" -d "{\"username\": \"Alice\", \"old_password\": \"Password123!\", \"new_password\": \"Password1234!\"}"
4. On the login page, log in with Alice's new credentials
5. (Optional) Feel free to change Alice's password back to Password123! since it's memorable

Run automated backend tests: python -m pytest backend/tests -v

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
