### PR TITLE
User Deletion Endpoint

### DIFF
--- a/ENDPOINTS_SUMMARY.md
+++ b/ENDPOINTS_SUMMARY.md
@@ -367,6 +367,24 @@ The following endpoint should be used when food_name is determined through machi
     500 Internal Server Error - Error adding transaction to database
     """
 
+    """
+    DELETE /profile/{username}
+
+    Description:
+    Delete all user data associated with the username.
+    The password for the user must be included for authentication.
+
+    Request Body (JSON):
+    {
+        "password": "string",   # required
+    }
+
+    Responses:
+    200 OK - Successfully deleted the user
+    400 Bad Request - Invalid argument
+    500 Internal Server Error - Error deleting the user
+    """
+
 ### Dining Locations
     """
     GET /locations/dining-locations

--- a/backend/endpoints/profile_endpoints.py
+++ b/backend/endpoints/profile_endpoints.py
@@ -3,6 +3,7 @@ from backend.services.profile_service import (
     edit_profile_json,
     retreive_profile_json,
     configured_json,
+    delete_profile_json,
 )
 
 profile_bp = Blueprint("profile", __name__)
@@ -103,3 +104,26 @@ def edit_profile():
     """
     data = request.json
     return edit_profile_json(data)
+
+
+@profile_bp.route("/<string:username>", methods=["DELETE"])
+def delete_profile(username):
+    """
+    DELETE /profile/{username}
+
+    Description:
+    Delete all user data associated with the username.
+    The password for the user must be included for authentication.
+
+    Request Body (JSON):
+    {
+        "password": "string",   # required
+    }
+
+    Responses:
+    200 OK - Successfully deleted the user
+    400 Bad Request - Invalid argument
+    500 Internal Server Error - Error deleting the user
+    """
+    data = request.json
+    return delete_profile_json(data, username)

--- a/backend/services/profile_service.py
+++ b/backend/services/profile_service.py
@@ -2,6 +2,8 @@
 from flask import jsonify
 
 # Project imports
+from backend.models.food_logging import FoodLogging
+from backend.models.users_auth import UsersAuth
 from backend.models.users_profile import UsersProfile
 from backend.extensions import db
 
@@ -113,5 +115,71 @@ def edit_profile_json(data):
         print(f"ProfileService: Update error: {e}")
         return (
             jsonify({"error": "Failed to update profile"}),
+            500,
+        )
+
+
+def delete_profile_json(data, username):
+    """Attempt to delete a user profile"""
+    password = data.get("password")
+
+    # Ensure password is present
+    if not isinstance(password, str) or len(password) == 0:
+        print("ProfileService: password is required")
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": "password is required",
+                }
+            ),
+            400,
+        )
+
+    # Ensure valid username and password pair
+    current_user = UsersAuth.get_user_by_name(username)
+    if current_user is None:
+        print(f"ProfileService: No matching username for {username}")
+        return (
+            jsonify({"status": "error", "message": "No matching username found"}),
+            400,
+        )
+
+    if not current_user.verify_password(password):
+        print("ProfileService: Password does not match.")
+        return (
+            jsonify({"status": "error", "message": "Password does not match."}),
+            400,
+        )
+
+    # Find the associated user profile
+    current_profile = UsersProfile.get_profile_by_name(username)
+
+    # Find all associated food transactions
+    user_logs = FoodLogging.query.filter_by(username=username).all()
+
+    try:
+        # Delete everything associated with the user
+        for log in user_logs:
+            db.session.delete(log)
+
+        if current_profile is not None:  # Check just in case
+            db.session.delete(current_profile)
+
+        db.session.delete(current_user)
+
+        db.session.commit()
+        print(f"ProfileService: Deletion complete for {username}.")
+
+        return (
+            jsonify({"message": "User deleted successfully"}),
+            200,
+        )
+
+    except Exception as e:
+        db.session.rollback()  # Ensure no partial changes are committed
+        print(f"ProfileService: Update error: {e}")
+        return (
+            jsonify({"error": "Failed to delete user"}),
             500,
         )

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -1,5 +1,9 @@
 # Project imports
-from backend.tests.test_helpers import seeded_users, add_test_user
+from backend.tests.test_helpers import (
+    seeded_users,
+    add_test_user,
+    seeded_transactions,
+)
 
 # Arguments like client and app are automatically injected from conftest.py
 # seeded_food_data is automatically injected from test_helpers.py
@@ -250,3 +254,82 @@ def test_edit_user_profile_no_optional_args(client, seeded_users):
 
     assert response.status_code == 200
     assert data["has_configured_settings"] is True
+
+
+# -------------------------------------
+# Testing Deleting User and their Data
+# -------------------------------------
+
+
+def test_delete_user_invalid_username(client, seeded_users):
+    response = client.delete("/profile/Alison", json={"password": "Password123!"})
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert "No matching username" in data["message"]
+
+
+def test_delete_user_invalid_password(client, seeded_users):
+    # Try missing password field
+    response = client.delete("/profile/Alice", json={"hello": "Alice"})
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert "password is required" in data["message"]
+
+    # Try wrong password
+    response = client.delete("/profile/Alice", json={"password": "AliceIsMe123!"})
+    data = response.get_json()
+
+    assert response.status_code == 400
+    assert "Password does not match" in data["message"]
+
+    # Check that the user has Alice has not been deleted (can't reuse username)
+    response = client.post(
+        "/auth/register", json={"username": "Alice", "password": "aaaaaBBBBB1@!"}
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 409
+    assert data["status"] == "error"
+    assert "This username is already in use." in data["message"]
+
+
+def test_delete_user_valid(client, seeded_users, seeded_transactions):
+    # Set Alice to be the only user contributing to global stats
+    client.post(
+        "/profile/edit",
+        json={"show_stats": True, "username": "Alice"},
+    )
+
+    response = client.get("/statistics/global?days=5")
+    data = response.get_json()
+
+    # Ensure trending items are influenced solely by Alice
+    assert data["trending_item_1"] == "Hamburger"
+    assert data["trending_item_2"] == "Caesar Salad"
+
+    # Now delete Alice and her data
+    response = client.delete("/profile/Alice", json={"password": "Password123!"})
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert "User deleted successfully" in data["message"]
+
+    # Check that Alice's logs have been deleted (trending items lost Alice's logs)
+    response = client.get("/statistics/global?days=5")
+    data = response.get_json()
+    assert data["trending_item_1"] == "Unknown"
+    assert data["trending_item_2"] == "Unknown"
+
+    # Check that the username Alice is now free
+    response = client.post(
+        "/auth/register", json={"username": "Alice", "password": "aaaaaBBBBB1@!"}
+    )
+
+    data = response.get_json()
+
+    assert response.status_code == 201
+    assert data["status"] == "success"
+    assert "User registered successfully." in data["message"]


### PR DESCRIPTION
# Description

Adds an endpoint to delete a user and their associated data. The endpoint requires the user-to-be-deleted's password to make sure attackers don't send a bunch of unauthenticated deletion requests.

Fixes # (issue)
- #102

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Manual tests
- [x] Linted/formatted

Manual Test:
1. Start the backend
      cd backend
      python -m venv backenv
      backenv\Scripts\activate
      pip install -r requirements.txt
      cd ..
      python -m backend.database.init_user_settings_db
      python -m backend.database.init_auth_db
      python -m backend.database.init_food_db
      python -m backend.database.init_logging_db
      python -m backend.app
2. Start the frontend
3. In the command prompt, try to delete Alice using the wrong password: curl -X DELETE http://127.0.0.1:5000/profile/Alice -H "Content-Type: application/json" -d "{\"password\": \"ThisIsAGuess123!\"}"
The JSON response should say 'password does not match'
4. In the command prompt, try to delete Alice using the right password: curl -X DELETE http://127.0.0.1:5000/profile/Alice -H "Content-Type: application/json" -d "{\"password\": \"Password123!\"}"
5. On the frontend, try to log in as Alice with Password123! : It should fail
6. Navigate to the "Register" page and create a new user named Alice (any password)
7. Navigate to the Saved Item page and check that it is empty - all the original Alice's data has been deleted

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
