### PR TITLE
Dining Location Statistics

### DIFF
--- a/ENDPOINTS_SUMMARY.md
+++ b/ENDPOINTS_SUMMARY.md
@@ -555,7 +555,7 @@ The following endpoint should be used when food_name is determined through machi
             "percent_fruit_veg": 43.21,
             "percent_grain": 29.53,
             "percent_protein": 15.85,
-            "top_dining_location": "Unknown",
+            "top_dining_location": "Starbucks",
             "top_food": "Chicken Salad",
             "total_calories": 1060,
             "total_carbs_g": 112.54,

--- a/backend/endpoints/statistics_endpoints.py
+++ b/backend/endpoints/statistics_endpoints.py
@@ -87,7 +87,7 @@ def get_aggregate_statistics(username):
             "percent_fruit_veg": 43.21,
             "percent_grain": 29.53,
             "percent_protein": 15.85,
-            "top_dining_location": "Unknown",
+            "top_dining_location": "Starbucks",
             "top_food": "Chicken Salad",
             "total_calories": 1060,
             "total_carbs_g": 112.54,

--- a/backend/models/food_item.py
+++ b/backend/models/food_item.py
@@ -179,4 +179,4 @@ def get_dining_location_name(dining_location_id):
     elif dining_location_id == 22:
         return "Thai Kitchen"
     else:
-        return ""
+        return "Unknown"

--- a/backend/services/statistics_service.py
+++ b/backend/services/statistics_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from flask import jsonify
 
 # Project imports
+from backend.models.food_item import get_dining_location_name
 from backend.models.food_logging import FoodLogging
 from backend.models.users_auth import UsersAuth
 from backend.models.users_profile import UsersProfile
@@ -132,7 +133,6 @@ def get_aggregate_statistics_json(username, days):
             "top_food": "Unknown",
             "top_dining_location": "Unknown",
         }
-        # Fiona TODO later: Implement dining location properly
 
         days_active = set()
         cal_fruit_veg = 0.0
@@ -140,6 +140,7 @@ def get_aggregate_statistics_json(username, days):
         cal_dairy = 0.0
         cal_protein = 0.0
         consumed_foods = []
+        visited_locations = []
 
         # Use each log to contribute to the various statistics
         for log in logs:
@@ -167,6 +168,9 @@ def get_aggregate_statistics_json(username, days):
                 aggregate_stats["total_sugar_g"] += log.sugar_g
 
             consumed_foods.append(log.food_name)
+
+            if log.dining_location != -1:
+                visited_locations.append(log.dining_location)
 
         # Make sure the user has logged at least one item
         if aggregate_stats["items_logged"] == 0:
@@ -204,6 +208,13 @@ def get_aggregate_statistics_json(username, days):
 
         # Calculate the most frequent food
         aggregate_stats["top_food"] = max(consumed_foods, key=consumed_foods.count)
+
+        # Calculate the most frequent dining location
+        if len(visited_locations) > 0:
+            most_common_location_id = Counter(visited_locations).most_common(1)[0][0]
+            aggregate_stats["top_dining_location"] = get_dining_location_name(
+                most_common_location_id
+            )
 
         # Convert calories to an integer for consistency
         aggregate_stats["total_calories"] = int(

--- a/backend/services/statistics_service.py
+++ b/backend/services/statistics_service.py
@@ -251,16 +251,24 @@ def get_global_statistics_json(days):
             "trending_location_2": "Unknown",
             "trending_location_3": "Unknown",
         }
-        # Fiona TODO later: Implement dining location properly
 
         consumed_foods = []
+        visited_locations = []
         for log in logs:
             consumed_foods.append(log.food_name)
+
+            if log.dining_location != -1:
+                visited_locations.append(log.dining_location)
 
         # Calculate the most frequent foods
         top_foods = Counter(consumed_foods).most_common(5)
         for i, (food, count) in enumerate(top_foods, 1):
             aggregate_stats[f"trending_item_{i}"] = food
+
+        # Calculate the most frequent dining locations
+        top_location_ids = Counter(visited_locations).most_common(3)
+        for i, (id, count) in enumerate(top_location_ids, 1):
+            aggregate_stats[f"trending_location_{i}"] = get_dining_location_name(id)
 
         return jsonify(aggregate_stats), 200
 

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -198,8 +198,8 @@ def seeded_dining_location_data(app):
 def seeded_dining_locations(app):
     """Setup a small dining_locations DB for each test in this file."""
     add_test_dining_location(app, "Tim Hortons")
-    add_test_dining_location(app, "Starbucks")
-    add_test_dining_location(app, "Bridgehead")
+    add_test_dining_location(app, "Subway")
+    add_test_dining_location(app, "Colonel by Chicken")
 
     yield  # test runs here
 

--- a/backend/tests/test_statistics.py
+++ b/backend/tests/test_statistics.py
@@ -204,7 +204,7 @@ def test_get_aggregate_statistics_success(
     assert abs(total_percent - 100.0) < 0.1
 
     assert data["top_food"] == "Hamburger"
-    assert isinstance(data["top_dining_location"], str)  # Unknown for now
+    assert data["top_dining_location"] == "Tim Hortons"
 
     # Test default days (should match because Alice consumed no new items)
     response2 = client.get("/statistics/aggregate/Alice")
@@ -246,7 +246,7 @@ def test_get_aggregate_statistics_small_window(
     assert abs(total_percent - 100.0) < 0.1
 
     assert data["top_food"] == "Banana Bread"
-    assert isinstance(data["top_dining_location"], str)  # Unknown for now
+    assert data["top_dining_location"] == "Colonel by Chicken"
 
 
 def test_get_global_statistics_success(
@@ -269,9 +269,9 @@ def test_get_global_statistics_success(
     assert data["trending_item_3"] == "Unknown"
     assert data["trending_item_4"] == "Unknown"
     assert data["trending_item_5"] == "Unknown"
-    assert isinstance(data["trending_location_1"], str)  # Unknown for now
-    assert isinstance(data["trending_location_2"], str)  # Unknown for now
-    assert isinstance(data["trending_location_3"], str)  # Unknown for now
+    assert data["trending_location_1"] == "Tim Hortons"
+    assert data["trending_location_2"] == "Subway"
+    assert data["trending_location_3"] == "Unknown"
 
     # Test default days (should match because Alice consumed no new items)
     response2 = client.get("/statistics/global")
@@ -301,9 +301,9 @@ def test_get_global_statistics_success(
     assert data3["trending_item_3"] == "Banana Bread"
     assert data3["trending_item_4"] == "Unknown"
     assert data3["trending_item_5"] == "Unknown"
-    assert isinstance(data3["trending_location_1"], str)  # Unknown for now
-    assert isinstance(data3["trending_location_2"], str)  # Unknown for now
-    assert isinstance(data3["trending_location_3"], str)  # Unknown for now
+    assert data["trending_location_1"] == "Tim Hortons"
+    assert data["trending_location_2"] == "Subway"
+    assert data["trending_location_3"] == "Unknown"
 
 
 def test_get_comparative_statistics_success(


### PR DESCRIPTION
# Description

Filled in the missing dining location statistics logic. The structure of the statistics endpoints is still the same as before, but now instead of always displaying "Unknown" dining location data will be shown if available.

Fixes # (issue)
- #104

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Manual tests
- [x] Linted/formatted

Manual Testing:
1. Start the Backend
2. Start the Frontend and Login as Alice (password123!)
3. In the command prompt, test the aggregate statistics endpoint using: curl -X GET "http://127.0.0.1:5000/statistics/aggregate/Alice?days=200"
4. Alice has eaten two items from Tim Hortons and one from Subway, so the top dining location should be Tim Hortons
5. On the frontend, use Browse by Dining Location to add two random Subway items to Alice's saved food item
6. Rerun the curl command, and now the top dining location will be Subway
7. Test the global statistics endpoint using: curl -X GET "http://127.0.0.1:5000/statistics/global?days=200"
8. The top trending location should be Subway, then Colonel By Chicken, then Tim Hortons
9. In the settings page, turn off show stats for Alice and press confirm - This removes her food items from the computation
10. Rerun the curl command, and now the top dining location should be Colonel By Chicken, followed by Subway, and lastly unknown. This is because only Bob and Dave's statistics are being used. (Bob had 2 items from Colonel by Chicken, one item from Subway and Dave had 1 item from Colonel By Chicken)

Automated Testing:
python -m pytest backend/tests -v

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
