### PR TITLE
Feature/frontend stats

### DIFF
--- a/frontend/cu-bytes/app/entries.tsx
+++ b/frontend/cu-bytes/app/entries.tsx
@@ -245,8 +245,6 @@ export default function EntriesScreen() {
                     Saved Food Items
                 </Text>
 
-                <View style={styles.headerContainer}></View>
-
                 <Text  id="loggedInUser"
                     style={styles.headerUsernameIcon}>
 
@@ -290,6 +288,7 @@ export default function EntriesScreen() {
 
                     <View style={styles.columnHeader}>
                         <Text style={styles.columnHeaderText}>Name</Text>
+                        <Text style={styles.columnHeaderText}>Dining Location</Text>
                         <Text style={styles.columnHeaderText}>Calories</Text>
                         <Text style={styles.columnHeaderText}>Carbs</Text>
                         <Text style={styles.columnHeaderText}>Fat</Text>
@@ -304,6 +303,7 @@ export default function EntriesScreen() {
                         renderItem={({ item }) => (
                         <View style={styles.row}>
                             <Text style={styles.rowCell}>{item["food_name"]}</Text>
+                            <Text style={styles.rowCell}>{item["dining_location"]}</Text>
                             <Text style={styles.rowCell}>{processFoodItemCalories(item["calories"])}</Text>
                             <Text style={styles.rowCell}>{processFoodItemCarbs(item["carbs_g"])} g</Text>
                             <Text style={styles.rowCell}>{processFoodItemFat(item["fat_g"])} g</Text>

--- a/frontend/cu-bytes/app/home.tsx
+++ b/frontend/cu-bytes/app/home.tsx
@@ -191,7 +191,7 @@ export default function HomeScreen() {
                 ]}
                 onPressIn={() => setIsGoalsPressed(true)}
                 onPressOut={() => setIsGoalsPressed(false)}
-                onPress={() => router.push("/goals")}
+                onPress={() => router.push("/statistics")}
                 disabled={ usernameGlobal == '' ? true : false }
             >
                 <Text id="goalsButtonText"

--- a/frontend/cu-bytes/app/home.tsx
+++ b/frontend/cu-bytes/app/home.tsx
@@ -197,7 +197,7 @@ export default function HomeScreen() {
                 <Text id="goalsButtonText"
                     style={styles.bodyButtonText}>
 
-                    Goals
+                    Statistics
                 </Text>
             </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
+
+import { router } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+
+import { styles } from './styles/style-home';
+import { useUser } from './context';
+
+export default function StatisticsScreen() {
+
+    const [loading, setLoading] = useState(false);
+    const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
+
+    /*
+        Variables used to store a copy of the logged-in user's username and profile settings 
+    */
+    const 
+        {
+            usernameGlobal,
+            hasEggAllergyGlobal,
+            hasFishOrShellfishAllergyGlobal,
+            hasDairyIntoleranceGlobal,
+            hasMilkAllergyGlobal,
+            hasPeanutAllergyGlobal,
+            hasSesameAllergyGlobal,
+            hasSoyAllergyGlobal,
+            hasTreenutAllergyGlobal,
+            hasWheatAllergyGlobal,
+            hasGlutenAllergyGlobal,
+            isVeganGlobal,
+            isVegetarianGlobal,
+            prefersHalalGlobal,
+            setUsernameGlobal,
+            setHasEggAllergyGlobal,
+            setHasFishOrShellfishAllergyGlobal,
+            setHasDairyIntoleranceGlobal,
+            setHasMilkAllergyGlobal,
+            setHasPeanutAllergyGlobal,
+            setHasSesameAllergyGlobal,
+            setHasSoyAllergyGlobal,
+            setHasTreenutAllergyGlobal,
+            setHasWheatAllergyGlobal,
+            setHasGlutenAllergyGlobal,
+            setIsVeganGlobal,
+            setIsVegetarianGlobal,
+            setPrefersHalalGlobal
+
+        } = useUser();
+
+    /*
+        Display the loading symbol while food items are being retrieved or logged
+    */
+    if (loading) {
+        return (
+            <View>
+                <ActivityIndicator size="large" />
+            </View>
+        );
+    }
+    
+    return (
+
+        <View style={styles.container}>
+
+            
+        </View>
+
+    )
+
+}

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { View, Text, TouchableOpacity, ActivityIndicator, FlatList } from 'react-native';
 
 import { router } from 'expo-router';
@@ -94,7 +94,25 @@ export default function StatisticsScreen() {
                 "items_logged": 0,
                 "proteins_g": 0,
                 "sugar_g": 0
-            }
+            },
+            "1900-01-02": {
+                "calories": 0,
+                "carbs_g": 0,
+                "fat_g": 0,
+                "fiber_g": 0,
+                "items_logged": 0,
+                "proteins_g": 0,
+                "sugar_g": 0
+            },
+            "1900-01-03": {
+                "calories": 0,
+                "carbs_g": 0,
+                "fat_g": 0,
+                "fiber_g": 0,
+                "items_logged": 0,
+                "proteins_g": 0,
+                "sugar_g": 0
+            },
         }
     );
 
@@ -179,27 +197,6 @@ export default function StatisticsScreen() {
 
         router.push('/');
     }
-
-    useEffect(() => {
-        const getStatistics = async () => {
-            try {
-                fetch(`http://127.0.0.1:5000/statistics/daily/${usernameGlobal}?`)
-                    .then( response => response.json() )
-                    .then( data => {
-                        setDailyStatistics(data);
-                        console.log(dailyStatistics);
-                    })
-                    .catch( error => { console.error(error) });
-            } catch (err) {
-                console.error(err);
-            } finally {
-                setLoading(false);
-            }
-        };
-
-        getStatistics();
-
-    }, []);
 
     /*
         Send a request to the backend endpoint to get the logged-in user's daily statistics
@@ -549,15 +546,63 @@ export default function StatisticsScreen() {
             )}
 
             {/* Display the fetched daily statistics */}
-            {selectedStatisticMode === 'Daily' && fetchedStatistics &&
+            {selectedStatisticMode === 'Daily' && fetchedStatistics && (
                 <View style={styles.bodyContainerDefault}>
 
                     <Text style={styles.infoText}>
                         Daily statistics for {usernameGlobal} over the last {numberOfDays} days
                     </Text>
 
-                    <View style={styles.bodyContainerAlt}>
+                    <View style={styles.bodyContainerDefault}>
+                        {Object.entries(dailyStatistics).map(([date, stats]) => (
 
+                            <View style={styles.bodyContainerAlt}>
+
+                                <Text
+                                    style={styles.statisticsInfoText}
+                                >
+                                    Date:
+                                    {'\n'}
+                                    Items Logged:
+                                    {'\n'}
+                                    Calories:
+                                    {'\n'}
+                                    Carbs:
+                                    {'\n'}
+                                    Fat:
+                                    {'\n'}
+                                    Fiber:
+                                    {'\n'}
+                                    Proteins:
+                                    {'\n'}
+                                    Sugar:
+                                    {'\n'}
+                                </Text>                                
+                            
+                                <Text
+                                    key={date}
+                                    style={styles.statisticsInfoText}
+                                >
+                                    {date}
+                                    {'\n'}
+                                    {stats.items_logged}
+                                    {'\n'}
+                                    {stats.calories}
+                                    {'\n'}
+                                    {stats.carbs_g} grams
+                                    {'\n'}
+                                    {stats.fat_g} grams
+                                    {'\n'}
+                                    {stats.fiber_g} grams
+                                    {'\n'}
+                                    {stats.proteins_g} grams
+                                    {'\n'}
+                                    {stats.sugar_g} grams
+                                    {'\n'}
+                                </Text>
+
+                            </View>
+                        ))}
                     </View>
 
                     <TouchableOpacity id="viewOtherStatsAgainButton"
@@ -580,7 +625,7 @@ export default function StatisticsScreen() {
                     </TouchableOpacity>
 
                 </View>
-            }
+            )}
 
             {/* Display the fetched aggregated statistics */}
             {selectedStatisticMode === 'Aggregate' && fetchedStatistics && (

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, ActivityIndicator } from 'react-native';
 
 import { router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -19,7 +19,7 @@ export default function StatisticsScreen() {
     const [isGlobalPressed, setIsGlobalPressed] = useState(false);
     const [isComparativePressed, setIsComparativePressed] = useState(false);
 
-    const [numberDays, setnumberDays] = useState(7);
+    const [numberOfDays, setNumberOfDays] = useState(7);
 
     /*
         Variables and setters used to store a copy of the logged-in user's username and profile settings
@@ -412,6 +412,36 @@ export default function StatisticsScreen() {
                     </Text>
 
                 </TouchableOpacity>                
+            )}
+
+            {/* Enter the number of days to include when retrieving the statistics */}
+            {selectedStatistic && (
+                <View>
+                    
+                    <TouchableOpacity id="increaseNumberOfDaysButton"
+                        onPress={() => setNumberOfDays(numberOfDays + 1)}
+                    >
+                        <Text id="increaseNumberOfDaysButtonText"
+                        >
+                            +
+                        </Text>
+
+                    </TouchableOpacity>
+
+                    <Text>
+                        {numberOfDays}
+                    </Text>
+
+                    <TouchableOpacity id="decreaseNumberOfDaysButton"
+                        onPress={() => {numberOfDays > 0 ? setNumberOfDays(numberOfDays - 1) : null }}
+                    >    
+                        <Text id="decreaseNumberOfDaysButtonText"
+                        >
+                            -
+                        </Text>
+                    </TouchableOpacity>
+
+                </View>
             )}
 
 

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -12,6 +12,10 @@ export default function StatisticsScreen() {
     const [loading, setLoading] = useState(false);
     const [isBackPressed, setIsBackPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
+    const [isDailyPressed, setIsDailyPressed] = useState(false);
+    const [isAggregatePressed, setIsAggregatePressed] = useState(false);
+    const [isGlobalPressed, setIsGlobalPressed] = useState(false);
+    const [isComparativePressed, setIsComparativePressed] = useState(false);
 
     /*
         Variables and setters used to store a copy of the logged-in user's username and profile settings
@@ -52,6 +56,81 @@ export default function StatisticsScreen() {
         } = useUser();
 
     /*
+        Variable and setter for storing and modifying the daily statistics of the logged-in user
+    */
+    const [dailyStatistics, setDailyStatistics] = useState(
+        {
+            "1900-01-01": {
+                "calories": 0,
+                "carbs_g": 0,
+                "fat_g": 0,
+                "fiber_g": 0,
+                "items_logged": 0,
+                "proteins_g": 0,
+                "sugar_g": 0
+            }
+        }
+    );
+
+    /*
+        Variable and setter for storing and modifying the aggregate statistics of the logged-in user
+    */
+    const [aggregateStatistics, setAggregateStatistics] = useState(
+        {
+            "days_active": 0,
+            "items_logged": 0,
+            "percent_dairy": 0,
+            "percent_fruit_veg": 0,
+            "percent_grain": 0,
+            "percent_protein": 0,
+            "top_dining_location": "Unknown",
+            "top_food": "Unknown",
+            "total_calories": 0,
+            "total_carbs_g": 0,
+            "total_fat_g": 0,
+            "total_fiber_g": 0,
+            "total_protein_g": 0,
+            "total_sugar_g": 0
+        }
+    );
+
+    /*
+        Variable and setter for storing and modifying the global statistics
+    */
+    const [globalStatistics, setGlobalStatistics] = useState(
+        {
+            "trending_item_1": "Unknown",
+            "trending_item_2": "Unknown",
+            "trending_item_3": "Unknown",
+            "trending_item_4": "Unknown",
+            "trending_item_5": "Unknown",
+            "trending_location_1": "Unknown",
+            "trending_location_2": "Unknown",
+            "trending_location_3": "Unknown",
+        }
+    );
+
+    /*
+        Variable and setter for storing and modifying the comparative statistics of the logged-in user
+    */
+    const [comparativeStatistics, setComparativeStatistics] = useState(
+        {
+            "balanced_food_groups_percentile": 0,
+            "balanced_macronutrients_percentile": 0,
+            "carbs_percentile": 0,
+            "checkin_percentile": 0,
+            "dairy_percentile": 0,
+            "fat_percentile": 0,
+            "fiber_percentile": 0,
+            "food_logging_percentile": 0,
+            "fruits_veg_percentile": 0,
+            "grain_percentile": 0,
+            "protein_fg_percentile": 0,
+            "sugar_percentile": 0
+        }
+    );
+
+    /*
         Log out the logged-in user by setting their username and profile settings to null, 
     */
     const logout = () => {
@@ -73,6 +152,82 @@ export default function StatisticsScreen() {
         setPrefersHalalGlobal(false);
 
         router.push('/');
+    }
+
+    /*
+        Send a request to the backend endpoint to get the logged-in user's daily statistics
+    */
+    const getDailyStats = async () => {
+        try {
+            fetch(`http://127.0.0.1:5000/statistics/daily/${usernameGlobal}`)
+                .then( response => response.json() )
+                .then( data => {
+                    setDailyStatistics(data);
+                    console.log(dailyStatistics);
+                })
+                .catch( error => { console.error(error) });
+        } catch (err) {
+            console.error(err);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    /*
+        Send a request to the backend endpoint to get the logged-in user's aggregate statistics
+    */
+    const getAggregateStats = async () => {
+        try {
+            fetch(`http://127.0.0.1:5000/statistics/aggregate/${usernameGlobal}`)
+                .then( response => response.json() )
+                .then( data => {
+                    setAggregateStatistics(data);
+                    console.log(aggregateStatistics);
+                })
+                .catch( error => { console.error(error) });
+        } catch (err) {
+            console.error(err);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    /*
+        Send a request to the backend endpoint to get the global statistics
+    */
+    const getGlobalStats = async () => {
+        try {
+            fetch(`http://127.0.0.1:5000/statistics/global`)
+                .then( response => response.json() )
+                .then( data => {
+                    setGlobalStatistics(data);
+                    console.log(globalStatistics);
+                })
+                .catch( error => { console.error(error) });
+        } catch (err) {
+            console.error(err);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    /*
+        Send a request to the backend endpoint to get the comparative statistics for the logged-in user
+    */
+    const getComparativeStats = async () => {
+        try {
+            fetch(`http://127.0.0.1:5000/statistics/comparative/${usernameGlobal}`)
+                .then( response => response.json() )
+                .then( data => {
+                    setComparativeStatistics(data);
+                    console.log(comparativeStatistics);
+                })
+                .catch( error => { console.error(error) });
+        } catch (err) {
+            console.error(err);
+        } finally {
+            setLoading(false);
+        }
     }
 
     /*
@@ -144,7 +299,85 @@ export default function StatisticsScreen() {
                     </TouchableOpacity>
 
             </View>
-            
+                    
+            <Text style={styles.infoText}>
+
+                What statistics would you like to view?
+            </Text>
+
+            {/* Daily Statistics */}
+            <TouchableOpacity id="dailyStatsButton"
+                style={[styles.bodyButtonDefault,
+                    { backgroundColor: isDailyPressed || usernameGlobal == '' ? '#666666' : '#131312' }
+                ]}
+                onPressIn={() => setIsDailyPressed(true)}
+                onPressOut={() => setIsDailyPressed(false)}
+                onPress={() => getDailyStats()}
+                disabled={ usernameGlobal == '' ? true : false }
+            >
+
+                <Text id="dailyStatsButtonText"
+                    style={styles.bodyButtonTextDefault}>
+
+                    Daily Statistics
+                </Text>
+
+            </TouchableOpacity>
+
+            {/* Aggregate Statistics */}
+            <TouchableOpacity id="aggregateStatsButton"
+                style={[styles.bodyButtonDefault,
+                    { backgroundColor: isAggregatePressed || usernameGlobal == '' ? '#666666' : '#131312' }
+                ]}
+                onPressIn={() => setIsAggregatePressed(true)}
+                onPressOut={() => setIsAggregatePressed(false)}
+                onPress={() => getAggregateStats()}
+            >
+
+                <Text id="aggregateStatsButtonText"
+                    style={styles.bodyButtonTextDefault}>
+
+                    Aggregate Statistics
+                </Text>
+
+            </TouchableOpacity>
+
+            {/* Global Statistics */}
+            <TouchableOpacity id="globalStatsButton"
+                style={[styles.bodyButtonDefault,
+                    { backgroundColor: isGlobalPressed || usernameGlobal == '' ? '#666666' : '#131312' }
+                ]}
+                onPressIn={() => setIsGlobalPressed(true)}
+                onPressOut={() => setIsGlobalPressed(false)}
+                onPress={() => getGlobalStats()}
+            >
+
+                <Text id="globalStatsButtonText"
+                    style={styles.bodyButtonTextDefault}>
+
+                    Global Statistics
+                </Text>
+
+            </TouchableOpacity>
+
+            {/* Comparative Statistics */}
+            <TouchableOpacity id="comparativeStatsButton"
+                style={[styles.bodyButtonDefault,
+                    { backgroundColor: isComparativePressed || usernameGlobal == '' ? '#666666' : '#131312' }
+                ]}
+                onPressIn={() => setIsComparativePressed(true)}
+                onPressOut={() => setIsComparativePressed(false)}
+                onPress={() => getComparativeStats()}
+            >
+
+                <Text id="comparativeStatsButtonText"
+                    style={styles.bodyButtonTextDefault}>
+
+                    Comparative Statistics
+                </Text>
+
+            </TouchableOpacity>
+
         </View>
 
     )

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -14,7 +14,8 @@ export default function StatisticsScreen() {
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
 
     /*
-        Variables used to store a copy of the logged-in user's username and profile settings 
+        Variables and setters used to store a copy of the logged-in user's username and profile settings
+        (Frontend copy updated based on the backend data)
     */
     const 
         {
@@ -33,6 +34,7 @@ export default function StatisticsScreen() {
             isVegetarianGlobal,
             prefersHalalGlobal,
             setUsernameGlobal,
+            setShowStatsGlobal,
             setHasEggAllergyGlobal,
             setHasFishOrShellfishAllergyGlobal,
             setHasDairyIntoleranceGlobal,
@@ -48,6 +50,30 @@ export default function StatisticsScreen() {
             setPrefersHalalGlobal
 
         } = useUser();
+
+    /*
+        Log out the logged-in user by setting their username and profile settings to null, 
+    */
+    const logout = () => {
+
+        setUsernameGlobal('');
+        setShowStatsGlobal(false);
+        setHasEggAllergyGlobal(false);
+        setHasFishOrShellfishAllergyGlobal(false);
+        setHasDairyIntoleranceGlobal(false);
+        setHasMilkAllergyGlobal(false);
+        setHasPeanutAllergyGlobal(false);
+        setHasSesameAllergyGlobal(false);
+        setHasSoyAllergyGlobal(false);
+        setHasTreenutAllergyGlobal(false);
+        setHasWheatAllergyGlobal(false);
+        setHasGlutenAllergyGlobal(false);
+        setIsVeganGlobal(false);
+        setIsVegetarianGlobal(false);
+        setPrefersHalalGlobal(false);
+
+        router.push('/');
+    }
 
     /*
         Display the loading symbol while food items are being retrieved or logged

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -4,7 +4,7 @@ import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 
-import { styles } from './styles/style-home';
+import { styles } from './styles/style-statistics';
 import { useUser } from './context';
 
 export default function StatisticsScreen() {
@@ -89,7 +89,61 @@ export default function StatisticsScreen() {
     return (
 
         <View style={styles.container}>
+            <StatusBar
+                style="auto"
+                hidden={true}
+            />
 
+            <View
+                style={styles.statusbar}>
+
+                <TouchableOpacity id="backButton"
+                    style={[styles.headerButton,
+                        { backgroundColor: isBackPressed ? '#666666' : '#131312' }
+                    ]}
+                    onPressIn={() => setIsBackPressed(true)}
+                    onPressOut={() => setIsBackPressed(false)}
+                    onPress={() => usernameGlobal != '' ? router.push('/home') : router.push('/')}>
+
+                    <Text id="backButtonText"
+                        style={styles.headerButtonText}>
+
+                        Back
+                    </Text>
+
+                </TouchableOpacity>
+
+                    <View style={styles.headerContainer}></View>
+
+                    <Text id="statisticsTitle"
+                        style={styles.headerTitle}>
+                        
+                        Statistics
+                    </Text>
+
+                    <Text id="loggedInUser"
+                        style={styles.headerUsernameIcon}>
+                    
+                        {usernameGlobal != '' ? `${usernameGlobal}` : 'Guest'}
+                    </Text>
+
+                    <TouchableOpacity id="loginLogoutButton"
+                        style={[styles.headerButton,
+                            { backgroundColor: isLoginLogoutPressed ? '#666666' : '#131312' }
+                        ]}
+                        onPressIn={() => setIsLoginLogoutPressed(true)}
+                        onPressOut={() => setIsLoginLogoutPressed(false)}
+                        onPress={() => usernameGlobal != '' ? logout() : router.push('/login')}>
+
+                        <Text id="loginLogoutButtonText"
+                            style={styles.headerButtonText}>
+
+                            {usernameGlobal != '' ? 'Logout' : 'Login' }
+                        </Text>
+
+                    </TouchableOpacity>
+
+            </View>
             
         </View>
 

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -10,12 +10,16 @@ import { useUser } from './context';
 export default function StatisticsScreen() {
 
     const [loading, setLoading] = useState(false);
+    const [selectedStatistic, setSelectedStatistic] = useState(false);
+    
     const [isBackPressed, setIsBackPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
     const [isDailyPressed, setIsDailyPressed] = useState(false);
     const [isAggregatePressed, setIsAggregatePressed] = useState(false);
     const [isGlobalPressed, setIsGlobalPressed] = useState(false);
     const [isComparativePressed, setIsComparativePressed] = useState(false);
+
+    const [numberDays, setnumberDays] = useState(7);
 
     /*
         Variables and setters used to store a copy of the logged-in user's username and profile settings
@@ -156,10 +160,13 @@ export default function StatisticsScreen() {
 
     /*
         Send a request to the backend endpoint to get the logged-in user's daily statistics
+
+        param(s):
+            days - number : The number of days to include in the statistics
     */
-    const getDailyStats = async () => {
+    const getDailyStats = async (days: number) => {
         try {
-            fetch(`http://127.0.0.1:5000/statistics/daily/${usernameGlobal}`)
+            fetch(`http://127.0.0.1:5000/statistics/daily/${usernameGlobal}?days=${days}`)
                 .then( response => response.json() )
                 .then( data => {
                     setDailyStatistics(data);
@@ -175,10 +182,13 @@ export default function StatisticsScreen() {
 
     /*
         Send a request to the backend endpoint to get the logged-in user's aggregate statistics
+
+        param(s):
+            days - number : The number of days to include in the statistics
     */
-    const getAggregateStats = async () => {
+    const getAggregateStats = async (days: number) => {
         try {
-            fetch(`http://127.0.0.1:5000/statistics/aggregate/${usernameGlobal}`)
+            fetch(`http://127.0.0.1:5000/statistics/aggregate/${usernameGlobal}?days=${days}`)
                 .then( response => response.json() )
                 .then( data => {
                     setAggregateStatistics(data);
@@ -194,10 +204,13 @@ export default function StatisticsScreen() {
 
     /*
         Send a request to the backend endpoint to get the global statistics
+
+        param(s):
+            days - number : The number of days to include in the statistics
     */
-    const getGlobalStats = async () => {
+    const getGlobalStats = async (days: number) => {
         try {
-            fetch(`http://127.0.0.1:5000/statistics/global`)
+            fetch(`http://127.0.0.1:5000/statistics/global?days=${days}`)
                 .then( response => response.json() )
                 .then( data => {
                     setGlobalStatistics(data);
@@ -213,10 +226,13 @@ export default function StatisticsScreen() {
 
     /*
         Send a request to the backend endpoint to get the comparative statistics for the logged-in user
+
+        param(s):
+            days - number : The number of days to include in the statistics
     */
-    const getComparativeStats = async () => {
+    const getComparativeStats = async (days: number) => {
         try {
-            fetch(`http://127.0.0.1:5000/statistics/comparative/${usernameGlobal}`)
+            fetch(`http://127.0.0.1:5000/statistics/comparative/${usernameGlobal}?days=${days}`)
                 .then( response => response.json() )
                 .then( data => {
                     setComparativeStatistics(data);
@@ -306,77 +322,98 @@ export default function StatisticsScreen() {
             </Text>
 
             {/* Daily Statistics */}
-            <TouchableOpacity id="dailyStatsButton"
-                style={[styles.bodyButtonDefault,
-                    { backgroundColor: isDailyPressed || usernameGlobal == '' ? '#666666' : '#131312' }
-                ]}
-                onPressIn={() => setIsDailyPressed(true)}
-                onPressOut={() => setIsDailyPressed(false)}
-                onPress={() => getDailyStats()}
-                disabled={ usernameGlobal == '' ? true : false }
-            >
+            {!selectedStatistic && (
+                <TouchableOpacity id="dailyStatsButton"
+                    style={[styles.bodyButtonDefault,
+                        { backgroundColor: isDailyPressed || usernameGlobal == '' ? '#666666' : '#131312' }
+                    ]}
+                    onPressIn={() => setIsDailyPressed(true)}
+                    onPressOut={() => setIsDailyPressed(false)}
+                    onPress={() =>
+                        setSelectedStatistic(true)
+                        //getDailyStats()
+                    }
+                    disabled={ usernameGlobal == '' ? true : false }
+                >
 
-                <Text id="dailyStatsButtonText"
-                    style={styles.bodyButtonTextDefault}>
+                    <Text id="dailyStatsButtonText"
+                        style={styles.bodyButtonTextDefault}>
 
-                    Daily Statistics
-                </Text>
+                        Daily Statistics
+                    </Text>
 
-            </TouchableOpacity>
+                </TouchableOpacity>                
+            )}
 
             {/* Aggregate Statistics */}
-            <TouchableOpacity id="aggregateStatsButton"
-                style={[styles.bodyButtonDefault,
-                    { backgroundColor: isAggregatePressed || usernameGlobal == '' ? '#666666' : '#131312' }
-                ]}
-                onPressIn={() => setIsAggregatePressed(true)}
-                onPressOut={() => setIsAggregatePressed(false)}
-                onPress={() => getAggregateStats()}
-            >
+            {!selectedStatistic && (
+                <TouchableOpacity id="aggregateStatsButton"
+                    style={[styles.bodyButtonDefault,
+                        { backgroundColor: isAggregatePressed || usernameGlobal == '' ? '#666666' : '#131312' }
+                    ]}
+                    onPressIn={() => setIsAggregatePressed(true)}
+                    onPressOut={() => setIsAggregatePressed(false)}
+                    onPress={() => 
+                        setSelectedStatistic(true)    
+                        //getAggregateStats()
+                    }
+                >
 
-                <Text id="aggregateStatsButtonText"
-                    style={styles.bodyButtonTextDefault}>
+                    <Text id="aggregateStatsButtonText"
+                        style={styles.bodyButtonTextDefault}>
 
-                    Aggregate Statistics
-                </Text>
+                        Aggregate Statistics
+                    </Text>
 
-            </TouchableOpacity>
+                </TouchableOpacity>                
+            )}
 
             {/* Global Statistics */}
-            <TouchableOpacity id="globalStatsButton"
-                style={[styles.bodyButtonDefault,
-                    { backgroundColor: isGlobalPressed || usernameGlobal == '' ? '#666666' : '#131312' }
-                ]}
-                onPressIn={() => setIsGlobalPressed(true)}
-                onPressOut={() => setIsGlobalPressed(false)}
-                onPress={() => getGlobalStats()}
-            >
+            {!selectedStatistic && (
+                <TouchableOpacity id="globalStatsButton"
+                    style={[styles.bodyButtonDefault,
+                        { backgroundColor: isGlobalPressed || usernameGlobal == '' ? '#666666' : '#131312' }
+                    ]}
+                    onPressIn={() => setIsGlobalPressed(true)}
+                    onPressOut={() => setIsGlobalPressed(false)}
+                    onPress={() => 
+                        setSelectedStatistic(true)
+                        //getGlobalStats()
+                    }
+                >
 
-                <Text id="globalStatsButtonText"
-                    style={styles.bodyButtonTextDefault}>
+                    <Text id="globalStatsButtonText"
+                        style={styles.bodyButtonTextDefault}>
 
-                    Global Statistics
-                </Text>
+                        Global Statistics
+                    </Text>
 
-            </TouchableOpacity>
+                </TouchableOpacity>                
+            )}
 
             {/* Comparative Statistics */}
-            <TouchableOpacity id="comparativeStatsButton"
-                style={[styles.bodyButtonDefault,
-                    { backgroundColor: isComparativePressed || usernameGlobal == '' ? '#666666' : '#131312' }
-                ]}
-                onPressIn={() => setIsComparativePressed(true)}
-                onPressOut={() => setIsComparativePressed(false)}
-                onPress={() => getComparativeStats()}
-            >
+            {!selectedStatistic && (
+                <TouchableOpacity id="comparativeStatsButton"
+                    style={[styles.bodyButtonDefault,
+                        { backgroundColor: isComparativePressed || usernameGlobal == '' ? '#666666' : '#131312' }
+                    ]}
+                    onPressIn={() => setIsComparativePressed(true)}
+                    onPressOut={() => setIsComparativePressed(false)}
+                    onPress={() =>
+                        setSelectedStatistic(true)
+                        //getComparativeStats()
+                    }
+                >
 
-                <Text id="comparativeStatsButtonText"
-                    style={styles.bodyButtonTextDefault}>
+                    <Text id="comparativeStatsButtonText"
+                        style={styles.bodyButtonTextDefault}>
 
-                    Comparative Statistics
-                </Text>
+                        Comparative Statistics
+                    </Text>
 
-            </TouchableOpacity>
+                </TouchableOpacity>                
+            )}
+
 
         </View>
 

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { View, Text, TextInput, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { useEffect, useState } from 'react';
+import { View, Text, TouchableOpacity, ActivityIndicator, FlatList } from 'react-native';
 
 import { router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -10,7 +10,29 @@ import { useUser } from './context';
 export default function StatisticsScreen() {
 
     const [loading, setLoading] = useState(false);
-    const [selectedStatistic, setSelectedStatistic] = useState(false);
+
+    /*
+        Variable and setter used to track whether one of the statistic mode buttons has been pressed
+        Initialized with the value false
+        Set to the value true everytime a statistics mode button is pressed
+        Set to the value false everytime a statistics fetch button is pressed
+    */
+    const [statisticModeButtonPressed, setStatisticModeButtonPressed] = useState(false);
+
+    /*
+        Variable and setter used to track what statistic mode button has specifically been pressed
+        Initialized with the value ""
+        Set to the value "Daily", "Aggregate", "Global", or "Comparative" everytime a statistics mode button is pressed
+        Set to the value "" everytime a statistics fetch button is pressed
+    */
+    const [selectedStatisticMode, setSelectedStatisticMode] = useState("");
+
+    /*
+        Variable and setter used to track whether any statistics have been fetched from the backend
+        Initialized with the value false
+        Set to the value true everytime a statistics fetch button is pressed
+    */
+    const [fetchedStatistics, setFetchedStatistics] = useState(false);
     
     const [isBackPressed, setIsBackPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
@@ -158,6 +180,27 @@ export default function StatisticsScreen() {
         router.push('/');
     }
 
+    useEffect(() => {
+        const getStatistics = async () => {
+            try {
+                fetch(`http://127.0.0.1:5000/statistics/daily/${usernameGlobal}?`)
+                    .then( response => response.json() )
+                    .then( data => {
+                        setDailyStatistics(data);
+                        console.log(dailyStatistics);
+                    })
+                    .catch( error => { console.error(error) });
+            } catch (err) {
+                console.error(err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        getStatistics();
+
+    }, []);
+
     /*
         Send a request to the backend endpoint to get the logged-in user's daily statistics
 
@@ -179,7 +222,7 @@ export default function StatisticsScreen() {
             setLoading(false);
         }
     }
-
+    
     /*
         Send a request to the backend endpoint to get the logged-in user's aggregate statistics
 
@@ -315,27 +358,35 @@ export default function StatisticsScreen() {
                     </TouchableOpacity>
 
             </View>
-                    
-            <Text style={styles.infoText}>
 
-                What statistics would you like to view?
-            </Text>
+            {/* Display the following message when no statistics buttons have been pressed and no statistics have been fetched */}
+            {!statisticModeButtonPressed && !fetchedStatistics && (
+                <Text style={styles.infoText}>
+                    What statistics would you like to view?
+                </Text>
+            )}
+            
+            {/* Display the following message when a statistics button has been pressed but no statistics have been fetched */}
+            {statisticModeButtonPressed && !fetchedStatistics && (
+                <Text style={styles.infoText}>
+                    Enter the number of days to include in the retrieved statistics
+                </Text>
+            )}
 
-            {/* Daily Statistics */}
-            {!selectedStatistic && (
+            {/* Display the button used to notify the frontend to retrieve daily statistics */}
+            {!statisticModeButtonPressed && (
                 <TouchableOpacity id="dailyStatsButton"
                     style={[styles.bodyButtonDefault,
                         { backgroundColor: isDailyPressed || usernameGlobal == '' ? '#666666' : '#131312' }
                     ]}
                     onPressIn={() => setIsDailyPressed(true)}
                     onPressOut={() => setIsDailyPressed(false)}
-                    onPress={() =>
-                        setSelectedStatistic(true)
-                        //getDailyStats()
-                    }
+                    onPress={() => {
+                        setStatisticModeButtonPressed(true)
+                        setSelectedStatisticMode("Daily")
+                    }}
                     disabled={ usernameGlobal == '' ? true : false }
                 >
-
                     <Text id="dailyStatsButtonText"
                         style={styles.bodyButtonTextDefault}>
 
@@ -345,20 +396,20 @@ export default function StatisticsScreen() {
                 </TouchableOpacity>                
             )}
 
-            {/* Aggregate Statistics */}
-            {!selectedStatistic && (
+            {/* Display the button used to notify the frontend to retrieve aggregate statistics */}
+            {!statisticModeButtonPressed && (
                 <TouchableOpacity id="aggregateStatsButton"
                     style={[styles.bodyButtonDefault,
                         { backgroundColor: isAggregatePressed || usernameGlobal == '' ? '#666666' : '#131312' }
                     ]}
                     onPressIn={() => setIsAggregatePressed(true)}
                     onPressOut={() => setIsAggregatePressed(false)}
-                    onPress={() => 
-                        setSelectedStatistic(true)    
-                        //getAggregateStats()
-                    }
+                    onPress={() => {
+                        setStatisticModeButtonPressed(true)    
+                        setSelectedStatisticMode("Aggregate");
+                    }}
+                    disabled={ usernameGlobal == '' ? true : false }
                 >
-
                     <Text id="aggregateStatsButtonText"
                         style={styles.bodyButtonTextDefault}>
 
@@ -368,20 +419,20 @@ export default function StatisticsScreen() {
                 </TouchableOpacity>                
             )}
 
-            {/* Global Statistics */}
-            {!selectedStatistic && (
+            {/* Display the button used to notify the frontend to retrieve global statistics */}
+            {!statisticModeButtonPressed && (
                 <TouchableOpacity id="globalStatsButton"
                     style={[styles.bodyButtonDefault,
                         { backgroundColor: isGlobalPressed || usernameGlobal == '' ? '#666666' : '#131312' }
                     ]}
                     onPressIn={() => setIsGlobalPressed(true)}
                     onPressOut={() => setIsGlobalPressed(false)}
-                    onPress={() => 
-                        setSelectedStatistic(true)
-                        //getGlobalStats()
-                    }
+                    onPress={() => {
+                        setStatisticModeButtonPressed(true)
+                        setSelectedStatisticMode("Global")
+                    }}
+                    disabled={ usernameGlobal == '' ? true : false }
                 >
-
                     <Text id="globalStatsButtonText"
                         style={styles.bodyButtonTextDefault}>
 
@@ -391,20 +442,20 @@ export default function StatisticsScreen() {
                 </TouchableOpacity>                
             )}
 
-            {/* Comparative Statistics */}
-            {!selectedStatistic && (
+            {/* Display the button used to notify the frontend to retrieve comparative statistics */}
+            {!statisticModeButtonPressed && (
                 <TouchableOpacity id="comparativeStatsButton"
                     style={[styles.bodyButtonDefault,
                         { backgroundColor: isComparativePressed || usernameGlobal == '' ? '#666666' : '#131312' }
                     ]}
                     onPressIn={() => setIsComparativePressed(true)}
                     onPressOut={() => setIsComparativePressed(false)}
-                    onPress={() =>
-                        setSelectedStatistic(true)
-                        //getComparativeStats()
-                    }
+                    onPress={() => {
+                        setStatisticModeButtonPressed(true)
+                        setSelectedStatisticMode("Comparative")
+                    }}
+                    disabled={ usernameGlobal == '' ? true : false }
                 >
-
                     <Text id="comparativeStatsButtonText"
                         style={styles.bodyButtonTextDefault}>
 
@@ -414,36 +465,378 @@ export default function StatisticsScreen() {
                 </TouchableOpacity>                
             )}
 
-            {/* Enter the number of days to include when retrieving the statistics */}
-            {selectedStatistic && (
-                <View>
-                    
-                    <TouchableOpacity id="increaseNumberOfDaysButton"
-                        onPress={() => setNumberOfDays(numberOfDays + 1)}
-                    >
-                        <Text id="increaseNumberOfDaysButtonText"
+            {/* Display buttons to increase/decrease the number of days to include when retrieving the statistics */}
+            {statisticModeButtonPressed && !fetchedStatistics && (
+                <View style={styles.bodyContainerDefault}>
+
+                    <View style={styles.bodyContainerAlt}>
+
+                        <TouchableOpacity id="decreaseNumberOfDaysButton"
+                            style={styles.bodyButtonDecreaseNumberOfDays}
+                            onPress={() => {numberOfDays > 3 ? setNumberOfDays(numberOfDays-1) : null}}
+                        >    
+                            <Text id="decreaseNumberOfDaysButtonText"
+                                style={styles.bodyButtonTextDecreaseNumberOfDays}
+                            >
+                                -
+                            </Text>
+                        </TouchableOpacity>
+
+                        <Text style={styles.numberOfDaysText}>{numberOfDays}</Text>                        
+                        
+                        <TouchableOpacity id="increaseNumberOfDaysButton"
+                            style={styles.bodyButtonIncreaseNumberOfDays}
+                            onPress={() => setNumberOfDays(numberOfDays+1)}
                         >
-                            +
+                            <Text id="increaseNumberOfDaysButtonText"
+                                style={styles.bodyButtonTextIncreaseNumberOfDays}
+                            >
+                                +
+                            </Text>
+                        </TouchableOpacity>
+
+                    </View>
+                    
+                    <TouchableOpacity id="getStatsButton"
+                        style={[styles.bodyButtonDefault,
+                            { backgroundColor: isLoginLogoutPressed ? '#666666' : '#131312' }
+                        ]}
+                        onPress={() => {
+                            { 
+                                selectedStatisticMode === 'Daily' ? getDailyStats(numberOfDays) :
+                                selectedStatisticMode === 'Aggregate' ? getAggregateStats(numberOfDays) :
+                                selectedStatisticMode === 'Global' ? getGlobalStats(numberOfDays) :
+                                selectedStatisticMode === 'Comparative' ? getComparativeStats(numberOfDays) :
+                                null
+                            }
+                            setFetchedStatistics(true)
+                        }}
+                    >    
+                        <Text id="getStatsButtonText"
+                            style={styles.bodyButtonTextDefault} 
+                        >
+                            { 
+                                selectedStatisticMode === 'Daily' ? 'Get Daily Statistics' :
+                                selectedStatisticMode === 'Aggregate' ? 'Get Aggregate Statistics' :
+                                selectedStatisticMode === 'Global' ? 'Get Global Statistics' :
+                                selectedStatisticMode === 'Comparative' ? 'Get Comparative Statistics' :
+                                ''
+                            }
                         </Text>
 
                     </TouchableOpacity>
 
-                    <Text>
-                        {numberOfDays}
-                    </Text>
-
-                    <TouchableOpacity id="decreaseNumberOfDaysButton"
-                        onPress={() => {numberOfDays > 0 ? setNumberOfDays(numberOfDays - 1) : null }}
+                    <TouchableOpacity id="viewOtherStatsButton"
+                        style={[styles.bodyButtonDefault,
+                            { backgroundColor: isLoginLogoutPressed ? '#666666' : '#131312' }
+                        ]}
+                        onPress={() => {
+                            setStatisticModeButtonPressed(false)
+                            setSelectedStatisticMode("")
+                            setFetchedStatistics(false)
+                            setNumberOfDays(7)
+                        }}
                     >    
-                        <Text id="decreaseNumberOfDaysButtonText"
+                        <Text id="viewOtherStatsButtonText"
+                            style={styles.bodyButtonTextDefault} 
                         >
-                            -
+                            View Other Statistics
                         </Text>
+
                     </TouchableOpacity>
 
                 </View>
             )}
 
+            {/* Display the fetched daily statistics */}
+            {selectedStatisticMode === 'Daily' && fetchedStatistics &&
+                <View style={styles.bodyContainerDefault}>
+
+                    <Text style={styles.infoText}>
+                        Daily statistics for {usernameGlobal} over the last {numberOfDays} days
+                    </Text>
+
+                    <View style={styles.bodyContainerAlt}>
+
+                    </View>
+
+                    <TouchableOpacity id="viewOtherStatsAgainButton"
+                        style={[styles.bodyButtonDefault,
+                            { backgroundColor: isLoginLogoutPressed ? '#666666' : '#131312' }
+                        ]}
+                        onPress={() => {
+                            setStatisticModeButtonPressed(false)
+                            setSelectedStatisticMode("")
+                            setFetchedStatistics(false)
+                            setNumberOfDays(7)
+                        }}
+                    >
+                        <Text id="viewOtherStatsAgainButtonText" 
+                            style={styles.bodyButtonTextDefault}>
+
+                            View Other Statistics
+                        </Text>
+
+                    </TouchableOpacity>
+
+                </View>
+            }
+
+            {/* Display the fetched aggregated statistics */}
+            {selectedStatisticMode === 'Aggregate' && fetchedStatistics && (
+                <View style={styles.bodyContainerDefault}>
+
+                    <Text style={styles.infoText}>
+                        Aggregate statistics for {usernameGlobal} over the last {numberOfDays} days
+                    </Text>
+
+                    <View style={styles.bodyContainerAlt}>
+
+                        <Text style={styles.statisticsInfoText}>
+                            Days Active:
+                            {'\n'}
+                            Items Logged:
+                            {'\n'}
+                            Percent Dairy:
+                            {'\n'}
+                            Percent Fruits / Vegs:
+                            {'\n'}
+                            Percent Grain:
+                            {'\n'}
+                            Percent Protein:
+                            {'\n'}
+                            Top Dining Location:
+                            {'\n'}
+                            Top Food Item:
+                            {'\n'}                    
+                            Total Calories:
+                            {'\n'}
+                            Total Carbs:
+                            {'\n'}
+                            Total Fat:
+                            {'\n'}
+                            Total Fiber:
+                            {'\n'}
+                            Total Protein:
+                            {'\n'}
+                            Total Sugar:
+                            {'\n'}
+                        </Text>
+
+                        <Text style={styles.statisticsInfoText}>
+                            {aggregateStatistics.days_active}
+                            {'\n'}
+                            {aggregateStatistics.items_logged}
+                            {'\n'}
+                            {aggregateStatistics.percent_dairy} %
+                            {'\n'}
+                            {aggregateStatistics.percent_fruit_veg} %
+                            {'\n'}
+                            {aggregateStatistics.percent_grain} %
+                            {'\n'}
+                            {aggregateStatistics.percent_protein} %
+                            {'\n'}
+                            {aggregateStatistics.top_dining_location}
+                            {'\n'}
+                            {aggregateStatistics.top_food}
+                            {'\n'}                    
+                            {aggregateStatistics.total_calories}
+                            {'\n'}
+                            {aggregateStatistics.total_carbs_g} grams
+                            {'\n'}
+                            {aggregateStatistics.total_fat_g} grams
+                            {'\n'}
+                            {aggregateStatistics.total_fiber_g} grams
+                            {'\n'}
+                            {aggregateStatistics.total_protein_g} grams
+                            {'\n'}
+                            {aggregateStatistics.total_sugar_g} grams
+                            {'\n'}
+                        </Text>
+
+                    </View>
+
+                    <TouchableOpacity id="viewOtherStatsAgainButton"
+                        style={[styles.bodyButtonDefault,
+                            { backgroundColor: isLoginLogoutPressed ? '#666666' : '#131312' }
+                        ]}
+                        onPress={() => {
+                            setStatisticModeButtonPressed(false)
+                            setSelectedStatisticMode("")
+                            setFetchedStatistics(false)
+                            setNumberOfDays(7)
+                        }}
+                    >
+                        <Text id="viewOtherStatsAgainButtonText" 
+                            style={styles.bodyButtonTextDefault}>
+
+                            View Other Statistics
+                        </Text>
+
+                    </TouchableOpacity>
+
+                </View>
+            )}
+
+            {/* Display the fetched global statistics */}
+            {selectedStatisticMode === 'Global' && fetchedStatistics && (
+                <View style={styles.bodyContainerDefault}>
+
+                    <Text style={styles.infoText}>
+                        Global statistics for all users who agreed to share their data over the last {numberOfDays} days
+                    </Text>
+
+                    <View style={styles.bodyContainerAlt}>
+
+                        <Text style={styles.statisticsInfoText}>
+                            Trending Food Item:
+                            {'\n'}
+                            Trending Food Item:
+                            {'\n'}
+                            Trending Food Item:
+                            {'\n'}
+                            Trending Food Item:
+                            {'\n'}
+                            Trending Food Item:
+                            {'\n'}
+                            Trending Dining Location:
+                            {'\n'}
+                            Trending Dining Location:
+                            {'\n'}
+                            Trending Dining Location:
+                            {'\n'}
+                        </Text>
+
+                        <Text style={styles.statisticsInfoText}>
+                            {globalStatistics.trending_item_1}
+                            {'\n'}
+                            {globalStatistics.trending_item_2}
+                            {'\n'}
+                            {globalStatistics.trending_item_3}
+                            {'\n'}
+                            {globalStatistics.trending_item_4}
+                            {'\n'}
+                            {globalStatistics.trending_item_5}
+                            {'\n'}
+                            {globalStatistics.trending_location_1}
+                            {'\n'}
+                            {globalStatistics.trending_location_2}
+                            {'\n'}
+                            {globalStatistics.trending_location_3}
+                            {'\n'}
+                        </Text>
+
+                    </View>
+
+                    <TouchableOpacity id="viewOtherStatsAgainButton"
+                        style={[styles.bodyButtonDefault,
+                            { backgroundColor: isLoginLogoutPressed ? '#666666' : '#131312' }
+                        ]}
+                        onPress={() => {
+                            setStatisticModeButtonPressed(false)
+                            setSelectedStatisticMode("")
+                            setFetchedStatistics(false)
+                            setNumberOfDays(7)
+                        }}
+                    >
+                        <Text id="viewOtherStatsAgainButtonText" 
+                            style={styles.bodyButtonTextDefault}>
+
+                            View Other Statistics
+                        </Text>
+
+                    </TouchableOpacity>
+
+                </View>
+            )}
+            
+            {/* Display the fetched comparative statistics */}
+            {selectedStatisticMode === 'Comparative' && fetchedStatistics && (
+                <View style={styles.bodyContainerDefault}>
+
+                    <Text style={styles.infoText}>
+                        Here are the comparative statistics for all users who agreed to share their data over the last {numberOfDays} days
+                    </Text>
+
+                    <View style={styles.bodyContainerAlt}>
+
+                        <Text style={styles.statisticsInfoText}>
+                            Balanced Food Groups Percentile:
+                            {'\n'}
+                            Balanced Macronutrients Percentile:
+                            {'\n'}
+                            Carbs Percentile:
+                            {'\n'}
+                            Checkin Percentile:
+                            {'\n'}
+                            Dairy Percentile:
+                            {'\n'}
+                            Fat Percentile:
+                            {'\n'}
+                            Fiber Percentile:
+                            {'\n'}
+                            Food Logging Percentile:
+                            {'\n'}
+                            Fruits / Vegs Percentile:
+                            {'\n'}
+                            Grain Percentile:
+                            {'\n'}
+                            Protein Percentile:
+                            {'\n'}
+                            Sugar Percentile:
+                            {'\n'}
+                        </Text>
+
+                        <Text style={styles.statisticsInfoText}>
+                            {comparativeStatistics.balanced_food_groups_percentile}
+                            {'\n'}
+                            {comparativeStatistics.balanced_macronutrients_percentile}
+                            {'\n'}
+                            {comparativeStatistics.carbs_percentile}
+                            {'\n'}
+                            {comparativeStatistics.checkin_percentile}
+                            {'\n'}
+                            {comparativeStatistics.dairy_percentile}
+                            {'\n'}
+                            {comparativeStatistics.fat_percentile}
+                            {'\n'}
+                            {comparativeStatistics.fiber_percentile}
+                            {'\n'}
+                            {comparativeStatistics.food_logging_percentile}
+                            {'\n'}
+                            {comparativeStatistics.fruits_veg_percentile}
+                            {'\n'}
+                            {comparativeStatistics.grain_percentile}
+                            {'\n'}
+                            {comparativeStatistics.protein_fg_percentile}
+                            {'\n'}
+                            {comparativeStatistics.sugar_percentile}
+                            {'\n'}
+                        </Text>
+
+                    </View>
+
+                    <TouchableOpacity id="viewOtherStatsAgainButton"
+                        style={[styles.bodyButtonDefault,
+                            { backgroundColor: isLoginLogoutPressed ? '#666666' : '#131312' }
+                        ]}
+                        onPress={() => {
+                            setStatisticModeButtonPressed(false)
+                            setSelectedStatisticMode("")
+                            setFetchedStatistics(false)
+                            setNumberOfDays(7)
+                        }}
+                    >
+                        <Text id="viewOtherStatsAgainButtonText" 
+                            style={styles.bodyButtonTextDefault}>
+
+                            View Other Statistics
+                        </Text>
+
+                    </TouchableOpacity>
+
+                </View>
+            )}
 
         </View>
 

--- a/frontend/cu-bytes/app/styles/style-statistics.tsx
+++ b/frontend/cu-bytes/app/styles/style-statistics.tsx
@@ -136,4 +136,24 @@ export const styles = StyleSheet.create({
     textAlign: 'center',
   },
 
+  numberOfDaysTextInput: {
+    backgroundColor: "#FFFFFF",
+    color: '#131312',
+    borderColor: '#131312',
+    borderRadius: 15,
+    borderWidth: 2,
+    fontFamily: 'arial',
+    fontSize: '150%' as any,
+    marginTop: '5%' as any,
+    marginBottom: '2.5%' as any,
+    paddingTop: '1.5%' as any,
+    paddingBottom: '1.5%' as any,
+    paddingLeft: '1.5%' as any,
+    paddingRight: '1.5%' as any,
+    shadowColor: '#131312',
+    shadowOffset: { width: 2, height: 2 },
+    shadowRadius: 2,
+    width: '75%' as any,
+  },
+
 })

--- a/frontend/cu-bytes/app/styles/style-statistics.tsx
+++ b/frontend/cu-bytes/app/styles/style-statistics.tsx
@@ -1,5 +1,4 @@
 import { StyleSheet } from "react-native";
-import StatisticsScreen from "../statistics";
 
 export const styles = StyleSheet.create({
 
@@ -149,15 +148,6 @@ export const styles = StyleSheet.create({
   bodyButtonTextDefault: {
     backgroundColor: 'transparent',
     color: '#FFFFFF',
-    fontFamily: 'arial',
-    fontSize: '175%' as any,
-    fontWeight: 600,
-    textAlign: 'center',
-  },
-
-  bodyButtonTextAlt: {
-    backgroundColor: 'transparent',
-    color: '#C5151A',
     fontFamily: 'arial',
     fontSize: '175%' as any,
     fontWeight: 600,

--- a/frontend/cu-bytes/app/styles/style-statistics.tsx
+++ b/frontend/cu-bytes/app/styles/style-statistics.tsx
@@ -76,4 +76,64 @@ export const styles = StyleSheet.create({
     width: '10%' as any,
   },
 
+  infoText: {
+    backgroundColor: '#C5151A',
+    color: '#FFFFFF',
+    fontFamily: 'arial',
+    fontSize: '150%' as any,
+    fontWeight: 500,
+    marginTop: '0.5%' as any,
+    paddingTop: '5.0%' as any,
+    paddingBottom: '5.0%' as any,
+    textAlign: 'center',
+    textShadowColor: '#131312',
+    textShadowOffset: { width: 2, height: 2 },
+    textShadowRadius: 10,
+    width: '100%' as any,
+  },
+
+  bodyButtonDefault: {
+    alignItems: 'center',
+    backgroundColor: '#131312',
+    borderRadius: 50,
+    borderWidth: 4,
+    borderColor: '#131312',
+    marginTop: '2.5%' as any,
+    padding: '2.5%' as any,
+    width: '80%' as any,
+  },
+
+  bodyButtonTextDefault: {
+    backgroundColor: 'transparent',
+    color: '#FFFFFF',
+    fontFamily: 'arial',
+    fontSize: '175%' as any,
+    fontWeight: 600,
+    textAlign: 'center',
+  },
+
+  bodyButtonAlt: {
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 50,
+    borderWidth: 4,
+    borderColor: '#FFFFFF',
+    marginTop: '2.5%' as any,
+    marginBottom: '2.5%',
+    padding: '2.5%' as any,
+    shadowColor: '#131312',
+    shadowOffset: { width: 2, height: 2 },
+    shadowRadius: 10,
+    width: '80%' as any,
+  },
+
+  bodyButtonTextAlt: {
+    backgroundColor: 'transparent',
+    color: '#C5151A',
+    fontFamily: 'arial',
+    fontSize: '175%' as any,
+    fontWeight: 600,
+    textAlign: 'center',
+  },
+
 })

--- a/frontend/cu-bytes/app/styles/style-statistics.tsx
+++ b/frontend/cu-bytes/app/styles/style-statistics.tsx
@@ -1,0 +1,79 @@
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+
+    container: {
+        alignItems: 'center', // Horizontal
+        backgroundColor: '#C5151A',
+        flex: 1,
+        flexDirection: 'column',
+        justifyContent: 'flex-start', // Vertical
+        overflowY: 'scroll',
+        textAlign: 'center',
+        width: '100%' as any,
+    },
+
+    headerContainer: {
+        backgroundColor: '#C5151A',
+        width: '10%' as any,
+    },
+
+    bodyContainer: {
+        alignItems: 'center', // Horizontal
+        backgroundColor: '#FFFFFF',
+        width: '100%' as any,
+    },
+
+  statusbar: {
+    alignItems: 'center', // Horizontal
+    backgroundColor: '#C5151A',
+    flexDirection: 'row',
+    justifyContent: 'space-between', // Vertical
+    padding: '1.5%' as any,
+    textAlign: 'center',
+    width: '100%' as any,
+  },
+
+  headerButton: {
+    alignItems: 'center',
+    backgroundColor: '#131312',
+    borderRadius: 50,
+    borderWidth: 4,
+    borderColor: 'black',
+    color: 'red',
+    padding: '1.5%' as any,
+    width: '10%' as any,
+  },
+
+  headerButtonText: {
+    backgroundColor: 'transparent',
+    color: '#FFFFFF',
+    fontFamily: 'arial',
+    fontSize: '150%' as any,
+    fontWeight: 500,
+  },
+  
+  headerTitle: {
+    backgroundColor: '#C5151A',
+    color: '#FFFFFF',
+    fontFamily: 'arial',
+    fontSize: '300%' as any,
+    fontWeight: 800,
+    textAlign: 'center',
+    textShadowColor: '#131312',
+    textShadowOffset: { width: 2, height: 2 },
+    textShadowRadius: 10,
+    width: '50%' as any,
+  },
+
+  headerUsernameIcon: {
+    backgroundColor: '#C5151A',
+    color: '#FFFFFF',
+    fontFamily: 'arial',
+    fontSize: '150%' as any,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    width: '10%' as any,
+  },
+
+})

--- a/frontend/cu-bytes/app/styles/style-statistics.tsx
+++ b/frontend/cu-bytes/app/styles/style-statistics.tsx
@@ -1,28 +1,37 @@
 import { StyleSheet } from "react-native";
+import StatisticsScreen from "../statistics";
 
 export const styles = StyleSheet.create({
 
-    container: {
-        alignItems: 'center', // Horizontal
-        backgroundColor: '#C5151A',
-        flex: 1,
-        flexDirection: 'column',
-        justifyContent: 'flex-start', // Vertical
-        overflowY: 'scroll',
-        textAlign: 'center',
-        width: '100%' as any,
-    },
+  container: {
+    alignItems: 'center', // Horizontal
+    backgroundColor: '#C5151A',
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'flex-start', // Vertical
+    overflowY: 'scroll',
+    textAlign: 'center',
+    width: '100%' as any,
+  },
 
-    headerContainer: {
-        backgroundColor: '#C5151A',
-        width: '10%' as any,
-    },
+  headerContainer: {
+    backgroundColor: '#C5151A',
+    width: '10%' as any,
+  },
 
-    bodyContainer: {
-        alignItems: 'center', // Horizontal
-        backgroundColor: '#FFFFFF',
-        width: '100%' as any,
-    },
+  bodyContainerDefault: {
+    alignItems: 'center', // Horizontal
+    backgroundColor: '#C5151A',
+    width: '100%' as any,
+  },
+
+  bodyContainerAlt: {
+    alignItems: 'center', // Horizontal
+    backgroundColor: '#C5151A',
+    flexDirection: 'row',
+    justifyContent: 'center', // Vertical
+    width: '100%' as any,
+  },
 
   statusbar: {
     alignItems: 'center', // Horizontal
@@ -92,6 +101,40 @@ export const styles = StyleSheet.create({
     width: '100%' as any,
   },
 
+  statisticsInfoText: {
+    backgroundColor: '#FFFFFF',
+    color: '#131312',
+    fontFamily: 'arial',
+    fontSize: '150%' as any,
+    fontWeight: 600,
+    marginTop: '1.5%' as any,
+    marginBottom: '1.5%' as any,
+    paddingTop: '5.0%' as any,
+    paddingBottom: '5.0%' as any,
+    paddingLeft: '5.0%' as any,
+    width: '40%' as any,
+  },
+
+  numberOfDaysText: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 25,
+    borderWidth: 4,
+    borderColor: '#131312',
+    color: '#131312',
+    fontFamily: 'arial',
+    fontSize: '300%' as any,
+    fontWeight: 800,
+    marginTop: '0.5%' as any,
+    marginLeft: '5.0%' as any,
+    marginRight: '5.0%' as any,
+    paddingTop: '2.5%' as any,
+    paddingBottom: '2.5%' as any,
+    paddingLeft: '2.5%' as any,
+    paddingRight: '2.5%' as any,
+    textAlign: 'center',
+    width: '20%' as any,
+  },
+
   bodyButtonDefault: {
     alignItems: 'center',
     backgroundColor: '#131312',
@@ -112,21 +155,6 @@ export const styles = StyleSheet.create({
     textAlign: 'center',
   },
 
-  bodyButtonAlt: {
-    alignItems: 'center',
-    backgroundColor: '#FFFFFF',
-    borderRadius: 50,
-    borderWidth: 4,
-    borderColor: '#FFFFFF',
-    marginTop: '2.5%' as any,
-    marginBottom: '2.5%',
-    padding: '2.5%' as any,
-    shadowColor: '#131312',
-    shadowOffset: { width: 2, height: 2 },
-    shadowRadius: 10,
-    width: '80%' as any,
-  },
-
   bodyButtonTextAlt: {
     backgroundColor: 'transparent',
     color: '#C5151A',
@@ -136,24 +164,46 @@ export const styles = StyleSheet.create({
     textAlign: 'center',
   },
 
-  numberOfDaysTextInput: {
-    backgroundColor: "#FFFFFF",
-    color: '#131312',
+  bodyButtonIncreaseNumberOfDays: {
+    alignItems: 'center',
+    backgroundColor: '#697A37',
+    borderRadius: 50,
+    borderWidth: 6,
     borderColor: '#131312',
-    borderRadius: 15,
-    borderWidth: 2,
-    fontFamily: 'arial',
-    fontSize: '150%' as any,
-    marginTop: '5%' as any,
+    marginTop: '2.5%' as any,
     marginBottom: '2.5%' as any,
-    paddingTop: '1.5%' as any,
-    paddingBottom: '1.5%' as any,
-    paddingLeft: '1.5%' as any,
-    paddingRight: '1.5%' as any,
-    shadowColor: '#131312',
-    shadowOffset: { width: 2, height: 2 },
-    shadowRadius: 2,
-    width: '75%' as any,
+    padding: '1.5%' as any,
+    width: '25%' as any,
   },
+
+  bodyButtonDecreaseNumberOfDays: {
+    alignItems: 'center',
+    backgroundColor: '#FFB4B4',
+    borderRadius: 50,
+    borderWidth: 6,
+    borderColor: '#131312',
+    marginTop: '2.5%' as any,
+    marginBottom: '2.5%' as any,
+    padding: '1.5%' as any,
+    width: '25%' as any,
+  },
+
+  bodyButtonTextIncreaseNumberOfDays: {
+    backgroundColor: 'transparent',
+    color: '#FFFFFF',
+    fontFamily: 'arial',
+    fontSize: '300%' as any,
+    fontWeight: 800,
+    textAlign: 'center',
+  },
+  
+  bodyButtonTextDecreaseNumberOfDays: {
+    backgroundColor: 'transparent',
+    color: '#C5151A',
+    fontFamily: 'arial',
+    fontSize: '300%' as any,
+    fontWeight: 800,
+    textAlign: 'center',
+  }
 
 })


### PR DESCRIPTION
# Description

Implemented the statistics page on the frontend. Users can view daily, aggregate, global, and comparative statistics that are fetched from the backend endpoints. Users can toggle the number of days included in the fetched statistics.

The food entries page on the frontend was also updated to include a dining location name column.

Fixes # (issue)

- https://github.com/GAchuzia/cu-bytes/issues/61
- https://github.com/GAchuzia/cu-bytes/issues/118

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [X] Manual tests
- [ ] Linted/formatted

1. Start the backend
2. Start the frontend
3. Log in as Alice
4. Go to the statistics page
5. Select the type of statistics to fetch by pressing one of the statistics button (daily, aggregate, global, comparative)
6. Optionally, toggle the number of days to include in the fetched statistics and press the button
7. View the fetched statistics as displayed on the page

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
