### PR TITLE
Set up Azure Data Persistence

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,7 +1,18 @@
 import os
 from dotenv import load_dotenv
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+# Detect Azure environment (Azure will always create this variable)
+IS_AZURE = os.getenv("HOME") == "/home"
+
+# Set database directory
+if IS_AZURE:
+    DB_DIR = os.path.join(os.getenv("HOME"), "site", "wwwroot", "backend", "database")
+else:
+    DB_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "database")
+
+# Ensure database directory exists
+os.makedirs(DB_DIR, exist_ok=True)
+
 IDEAL_TARGETS = {
     "fat_pct": 0.275,
     "carbs_pct": 0.55,
@@ -25,29 +36,26 @@ class Config:
 
 class DevelopmentConfig(Config):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
-    # fmt: off
+    # If all models are properly linked SQLALCHEMY_DATABASE_URI actually does not matter
+    SQLALCHEMY_DATABASE_URI = f"sqlite:///{os.path.join(DB_DIR, 'main.db')}"  # noqa
     SQLALCHEMY_BINDS = {
-        "auth": f"sqlite:///{os.path.join(BASE_DIR, 'database/auth.db')}", # noqa
-        "profiles": f"sqlite:///{os.path.join(BASE_DIR, 'database/profiles.db')}", # noqa
-        "food_data": f"sqlite:///{os.path.join(BASE_DIR, 'database/food_data.db')}", # noqa
-        "logging": f"sqlite:///{os.path.join(BASE_DIR, 'database/logging.db')}", # noqa
+        "auth": f"sqlite:///{os.path.join(DB_DIR, 'auth.db')}",  # noqa
+        "profiles": f"sqlite:///{os.path.join(DB_DIR, 'profiles.db')}",  # noqa
+        "food_data": f"sqlite:///{os.path.join(DB_DIR, 'food_data.db')}",  # noqa
+        "logging": f"sqlite:///{os.path.join(DB_DIR, 'logging.db')}",  # noqa
     }
-    # fmt: on
     DEBUG = True
 
 
 class ProductionConfig(Config):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
-    # fmt: off
+    SQLALCHEMY_DATABASE_URI = f"sqlite:///{os.path.join(DB_DIR, 'main.db')}"  # noqa
     SQLALCHEMY_BINDS = {
-        "auth": f"sqlite:///{os.path.join(BASE_DIR, 'database/auth.db')}", # noqa
-        "profiles": f"sqlite:///{os.path.join(BASE_DIR, 'database/profiles.db')}", # noqa
-        "food_data": f"sqlite:///{os.path.join(BASE_DIR, 'database/food_data.db')}", # noqa
-        "logging": f"sqlite:///{os.path.join(BASE_DIR, 'database/logging.db')}", # noqa
+        "auth": f"sqlite:///{os.path.join(DB_DIR, 'auth.db')}",  # noqa
+        "profiles": f"sqlite:///{os.path.join(DB_DIR, 'profiles.db')}",  # noqa
+        "food_data": f"sqlite:///{os.path.join(DB_DIR, 'food_data.db')}",  # noqa
+        "logging": f"sqlite:///{os.path.join(DB_DIR, 'logging.db')}",  # noqa
     }
-    # fmt: on
     DEBUG = False
 
 


### PR DESCRIPTION
# Description
Attempting to set up databases on Azure. Currently the backend server on Azure can't do anything because it does not have any databases, so if this works, then we would actually be able to send requests to the Azure server. <ore work will need to be done to move the Scan food feature over, including storing best_model.pth on Azure, but this is a solid start that may also uncover other problems with the hosting.

These changes should not affect how the app runs locally.

Fixes # (issue)
- Azure server is useless

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [x] Manual tests
- [x] Linted/formatted

Manual Testing: All edits were made to config.py which dictates where the backend stores it's data. To make sure I did not break the locally-hosted backend, perform the following:
1. Go to backend/database and delete auth.db, food_data.db, logging.db and profiles.db
2. Run the commands to create and seed all the databases:
    cd backend
    python -m venv backenv
    backenv\Scripts\activate
    pip install -r requirements.txt
    cd ..
    python -m backend.database.init_user_settings_db
    python -m backend.database.init_auth_db
    python -m backend.database.init_food_db
    python -m backend.database.init_logging_db
3. Open the frontend
4. Login as Alice (Password123!) - if this is possible, auth.db is ok
5. Check Settings, and make sure stats enabled is on - if this is true, profiles.db is ok
6. Go to Browse Food and add any item - if browsing is not empty, food_data.db is ok
7. View saved items - if there is more than one item saved, logging.db is ok

The automated tests should not have been affected, but you can run them just in case:
python -m pytest backend/tests -v

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
