### PR TITLE
Fix food-item-by-name Endpoint

### DIFF
--- a/ENDPOINTS_SUMMARY.md
+++ b/ENDPOINTS_SUMMARY.md
@@ -162,10 +162,11 @@ Summary of endpoints.
     If the food name does not match a generic category the list of food ids
     will be empty.
 
+    Query Parameters:
+    - name (mandatory): Food Name
+
     Request Body:
-    {
-        "food_name": "Bagel"
-    }
+    None
 
     Responses:
     200 OK - Successfully retrieved the specified food item

--- a/backend/endpoints/browsing_endpoints.py
+++ b/backend/endpoints/browsing_endpoints.py
@@ -103,10 +103,11 @@ def get_food_item_by_name():
     If the food name does not match a generic category the list of food ids
     will be empty.
 
+    Query Parameters:
+    - name (mandatory): Food Name
+
     Request Body:
-    {
-        "food_name": "Bagel"
-    }
+    None
 
     Responses:
     200 OK - Successfully retrieved the specified food item
@@ -127,5 +128,6 @@ def get_food_item_by_name():
     400 Bad Request - Missing food_name parameter
     500 Internal Server Error - Database retrieval failed or unexpected error occurred
     """
-    data = request.json
-    return get_food_item_by_name_json(data)
+    food_name = request.args.get("name", default=None)
+
+    return get_food_item_by_name_json(food_name)

--- a/backend/services/browse_service.py
+++ b/backend/services/browse_service.py
@@ -64,11 +64,9 @@ def get_food_item_by_id_json(food_id):
         return {"error": "Failed to retrieve food item information"}, 500
 
 
-def get_food_item_by_name_json(data):
-    food_name = data.get("food_name")
-
+def get_food_item_by_name_json(food_name):
     # Validate input
-    if not isinstance(food_name, str) or len(food_name) == 0:
+    if food_name is None or len(food_name) == 0:
         print("BrowsingService: food_name is required and must be a non-empty string")
         return (
             jsonify(

--- a/backend/tests/test_browse.py
+++ b/backend/tests/test_browse.py
@@ -82,7 +82,7 @@ def test_get_nonexistant_food_item(client, seeded_food_data):
 # ------------------------------------
 def test_get_by_name_invalid(client, seeded_food_data):
     # Try missing food_name in JSON
-    response = client.get("/browse/food-item-by-name", json={"username": "Alice"})
+    response = client.get("/browse/food-item-by-name?name")
     data = response.get_json()
 
     assert response.status_code == 400
@@ -91,7 +91,7 @@ def test_get_by_name_invalid(client, seeded_food_data):
 
 def test_get_by_name_invalid_category(client, seeded_food_data):
     # Try non existent category
-    response = client.get("/browse/food-item-by-name", json={"food_name": "Alice"})
+    response = client.get("/browse/food-item-by-name?name=Alice")
     data = response.get_json()
 
     assert response.status_code == 200
@@ -100,7 +100,7 @@ def test_get_by_name_invalid_category(client, seeded_food_data):
 
 def test_get_by_name_valid_category(client, seeded_food_data):
     # Try valid category
-    response = client.get("/browse/food-item-by-name", json={"food_name": "Loaf"})
+    response = client.get("/browse/food-item-by-name?name=Loaf")
     data = response.get_json()
 
     assert response.status_code == 200
@@ -110,3 +110,15 @@ def test_get_by_name_valid_category(client, seeded_food_data):
     assert loaf["dining_location"] == "Tim Hortons"
     assert loaf["id"] == 3
     assert loaf["name"] == "Banana Bread"
+
+    # Try valid category containing a space
+    response = client.get("/browse/food-item-by-name?name=Green%20Salad")
+    data = response.get_json()
+
+    assert response.status_code == 200
+    assert len(data["food_items"]) == 1
+
+    loaf = data["food_items"][0]
+    assert loaf["dining_location"] == "Tim Hortons"
+    assert loaf["id"] == 1
+    assert loaf["name"] == "Caesar Salad"


### PR DESCRIPTION
# Description

The food-item-by-name was not formatted correctly for frontend usage (it had a request body). This set of changes moves the food name into a query parameter instead.

Fixes # (issue)
- Frontend could not use the food-item-by-name endpoint

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [x] Manual tests
- [x] Linted/formatted

Manual Testing:
1. Start the backend
2. In the terminal, run: curl -X GET "http://127.0.0.1:5000/browse/food-item-by-name?name=Bagel"
3. You should see a bunch of bagel-like items
4. Now test the case where there is a space in the generic category name: curl -X GET "http://127.0.0.1:5000/browse/food-item-by-name?name=French%20Fries"
5. You should see a bunch of french fry like items

Automated Testing:
python -m pytest backend/tests -v

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
