### PR TITLE
Feature/ml tests

### DIFF
--- a/backend/tests/test_ml_predict_endpoint.py
+++ b/backend/tests/test_ml_predict_endpoint.py
@@ -1,0 +1,189 @@
+import os
+from pathlib import Path
+
+import pytest
+
+import backend.services.ml_service as ml_service
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _list_images(folder: Path):
+    exts = {".jpg", ".jpeg", ".png", ".webp"}
+    if not folder.exists():
+        return []
+    return sorted(
+        [p for p in folder.iterdir() if p.is_file() and p.suffix.lower() in exts]
+    )
+
+
+def _take_subset(images, max_images: int):
+    # max_images <= 0 means "all"
+    if max_images <= 0:
+        return images
+    return images[:max_images]
+
+
+@pytest.fixture(scope="session")
+def ml_images_root():
+    """
+    Default test images:
+      machine-learning/data/evaluation_data
+
+    Override with env var ML_TEST_IMAGES_DIR if you move the data.
+    """
+    root = os.getenv("ML_TEST_IMAGES_DIR")
+    if root:
+        return Path(root)
+    return REPO_ROOT / "machine-learning" / "data" / "evaluation_data"
+
+
+@pytest.fixture(scope="session")
+def require_model_files():
+    if not (ml_service.MODEL_PATH.exists() and ml_service.CLASS_NAMES_PATH.exists()):
+        pytest.skip(
+            "Model files missing. Expected "
+            f"{ml_service.MODEL_PATH} and {ml_service.CLASS_NAMES_PATH}"
+        )
+
+
+@pytest.fixture(scope="session")
+def max_images():
+    # Keep tests fast. Set ML_TEST_MAX_IMAGES=0 to include all images.
+    return int(os.getenv("ML_TEST_MAX_IMAGES", "100"))
+
+
+@pytest.fixture(scope="session")
+def non_food_min_low_conf_ratio():
+    # Non-food images should usually be rejected by the confidence threshold.
+    return float(os.getenv("ML_TEST_NONFOOD_MIN_LOW_CONF_RATIO", "0.7"))
+
+
+def _post_image(client, image_path: Path):
+    with open(image_path, "rb") as f:
+        response = client.post(
+            "/ml/predict",
+            data={"image": (f, image_path.name)},
+            content_type="multipart/form-data",
+        )
+    return response
+
+
+def _assert_common_fields(payload: dict):
+    assert "success" in payload
+    assert "confidence" in payload
+    assert 0 <= float(payload["confidence"]) <= 100
+
+
+def _log_prediction(stage: str, image_path: Path, payload: dict):
+    confidence = payload.get("confidence")
+    success = payload.get("success")
+    food_name = payload.get("food_name")
+    reason = payload.get("reason")
+    message = payload.get("message")
+
+    print(
+        f"[{stage}] {image_path.name} | success={success} confidence={confidence} "
+        f"food_name={food_name} reason={reason} message={message}"
+    )
+
+
+def test_ml_predict_carleton_food_images_return_valid_response(
+    client, ml_images_root: Path, require_model_files, max_images: int
+):
+    folder = ml_images_root / "hey_chef_carleton"
+    images = _take_subset(_list_images(folder), max_images)
+    if not images:
+        pytest.skip(f"No images found in {folder}")
+
+    print(f"[ENDPOINT] Carleton food folder: {folder} | images={len(images)}")
+
+    success_true = 0
+    for image_path in images:
+        response = _post_image(client, image_path)
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        _log_prediction("ENDPOINT", image_path, payload)
+        _assert_common_fields(payload)
+
+        if payload["success"] is True:
+            success_true += 1
+            assert "food_name" in payload, f"Missing food_name for {image_path}"
+            assert "calories" in payload, f"Missing calories for {image_path}"
+        else:
+            assert (
+                payload.get("reason") == "low_confidence"
+            ), f"Expected low_confidence for {image_path} but got {payload}"
+            assert "message" in payload, f"Missing message for {image_path}"
+
+    print(f"[ENDPOINT] Accepted (success=True): {success_true}/{len(images)}")
+    assert success_true >= 1
+
+
+def test_ml_predict_non_food_images_are_low_confidence(
+    client,
+    ml_images_root: Path,
+    require_model_files,
+    max_images: int,
+    non_food_min_low_conf_ratio: float,
+):
+    folder = ml_images_root / "non_food"
+    images = _take_subset(_list_images(folder), max_images)
+    if not images:
+        pytest.skip(f"No images found in {folder}")
+
+    print(f"[ENDPOINT] Non-food folder: {folder} | images={len(images)}")
+
+    low_conf_count = 0
+    for image_path in images:
+        response = _post_image(client, image_path)
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        _log_prediction("ENDPOINT", image_path, payload)
+        _assert_common_fields(payload)
+
+        if payload["success"] is False:
+            assert (
+                payload.get("reason") == "low_confidence"
+            ), f"Expected low_confidence for {image_path} but got {payload}"
+            low_conf_count += 1
+
+    low_conf_ratio = low_conf_count / len(images)
+    print(f"[ENDPOINT] Low-confidence (rejected): {low_conf_count}/{len(images)} ratio={low_conf_ratio}")
+    assert low_conf_ratio >= non_food_min_low_conf_ratio
+
+
+def test_ml_predict_general_food_images_return_valid_response(
+    client, ml_images_root: Path, require_model_files, max_images: int
+):
+    folder = ml_images_root / "UPMC-Food101"
+    images = _take_subset(_list_images(folder), max_images)
+    if not images:
+        pytest.skip(f"No images found in {folder}")
+
+    print(f"[ENDPOINT] General foods folder: {folder} | images={len(images)}")
+
+    success_true = 0
+    for image_path in images:
+        response = _post_image(client, image_path)
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        _log_prediction("ENDPOINT", image_path, payload)
+        _assert_common_fields(payload)
+
+        if payload["success"] is True:
+            success_true += 1
+            assert "food_name" in payload, f"Missing food_name for {image_path}"
+            assert "calories" in payload, f"Missing calories for {image_path}"
+        else:
+            assert (
+                payload.get("reason") == "low_confidence"
+            ), f"Expected low_confidence for {image_path} but got {payload}"
+            assert "message" in payload, f"Missing message for {image_path}"
+
+    print(f"[ENDPOINT] Accepted (success=True): {success_true}/{len(images)}")
+    assert success_true >= 1

--- a/backend/tests/test_ml_predict_service.py
+++ b/backend/tests/test_ml_predict_service.py
@@ -1,0 +1,176 @@
+import os
+from pathlib import Path
+
+import pytest
+
+import backend.services.ml_service as ml_service
+from backend.services.ml_service import predict_food
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _list_images(folder: Path):
+    exts = {".jpg", ".jpeg", ".png", ".webp"}
+    if not folder.exists():
+        return []
+    return sorted(
+        [p for p in folder.iterdir() if p.is_file() and p.suffix.lower() in exts]
+    )
+
+
+def _take_subset(images, max_images: int):
+    # max_images <= 0 means "all"
+    if max_images <= 0:
+        return images
+    return images[:max_images]
+
+
+@pytest.fixture(scope="session")
+def ml_images_root():
+    """
+    Default test images:
+      machine-learning/data/evaluation_data
+
+    Override with env var ML_TEST_IMAGES_DIR if you move the data.
+    """
+    root = os.getenv("ML_TEST_IMAGES_DIR")
+    if root:
+        return Path(root)
+    return REPO_ROOT / "machine-learning" / "data" / "evaluation_data"
+
+
+@pytest.fixture(scope="session")
+def require_model_files():
+    if not (ml_service.MODEL_PATH.exists() and ml_service.CLASS_NAMES_PATH.exists()):
+        pytest.skip(
+            "Model files missing. Expected "
+            f"{ml_service.MODEL_PATH} and {ml_service.CLASS_NAMES_PATH}"
+        )
+
+
+@pytest.fixture(scope="session")
+def max_images():
+    # Keep tests fast. Set ML_TEST_MAX_IMAGES=0 to include all images.
+    return int(os.getenv("ML_TEST_MAX_IMAGES", "100"))
+
+
+@pytest.fixture(scope="session")
+def non_food_min_low_conf_ratio():
+    # Non-food images should usually be rejected by the confidence threshold.
+    return float(os.getenv("ML_TEST_NONFOOD_MIN_LOW_CONF_RATIO", "0.7"))
+
+
+def _assert_common_fields(result: dict):
+    assert isinstance(result, dict)
+    assert "success" in result
+    assert "confidence" in result
+    assert 0 <= float(result["confidence"]) <= 100
+
+
+def _log_prediction(stage: str, image_path: Path, result: dict):
+    confidence = result.get("confidence")
+    success = result.get("success")
+    food_name = result.get("food_name")
+    reason = result.get("reason")
+    message = result.get("message")
+
+    print(
+        f"[{stage}] {image_path.name} | success={success} confidence={confidence} "
+        f"food_name={food_name} reason={reason} message={message}"
+    )
+
+
+def test_predict_food_carleton_food_images_return_valid_response(
+    app, ml_images_root: Path, require_model_files, max_images: int
+):
+    folder = ml_images_root / "hey_chef_carleton"
+    images = _take_subset(_list_images(folder), max_images)
+    if not images:
+        pytest.skip(f"No images found in {folder}")
+
+    print(f"[SERVICE] Carleton food folder: {folder} | images={len(images)}")
+
+    success_true = 0
+    with app.app_context():
+        for image_path in images:
+            result = predict_food(str(image_path))
+            _log_prediction("SERVICE", image_path, result)
+            _assert_common_fields(result)
+
+            if result["success"] is True:
+                success_true += 1
+                assert "food_name" in result, f"Missing food_name for {image_path}"
+                assert "calories" in result, f"Missing calories for {image_path}"
+            else:
+                assert (
+                    result.get("reason") == "low_confidence"
+                ), f"Expected low_confidence for {image_path} but got {result}"
+                assert "message" in result, f"Missing message for {image_path}"
+
+    # At least one should be accepted as food.
+    print(f"[SERVICE] Accepted (success=True): {success_true}/{len(images)}")
+    assert success_true >= 1
+
+
+def test_predict_food_non_food_images_are_low_confidence(
+    app,
+    ml_images_root: Path,
+    require_model_files,
+    max_images: int,
+    non_food_min_low_conf_ratio: float,
+):
+    folder = ml_images_root / "non_food"
+    images = _take_subset(_list_images(folder), max_images)
+    if not images:
+        pytest.skip(f"No images found in {folder}")
+
+    print(f"[SERVICE] Non-food folder: {folder} | images={len(images)}")
+
+    low_conf_count = 0
+    with app.app_context():
+        for image_path in images:
+            result = predict_food(str(image_path))
+            _log_prediction("SERVICE", image_path, result)
+            _assert_common_fields(result)
+
+            if result["success"] is False:
+                assert (
+                    result.get("reason") == "low_confidence"
+                ), f"Expected low_confidence for {image_path} but got {result}"
+                low_conf_count += 1
+
+    low_conf_ratio = low_conf_count / len(images)
+    print(f"[SERVICE] Low-confidence (rejected): {low_conf_count}/{len(images)} ratio={low_conf_ratio}")
+    assert low_conf_ratio >= non_food_min_low_conf_ratio
+
+
+def test_predict_food_general_food_images_return_valid_response(
+    app, ml_images_root: Path, require_model_files, max_images: int
+):
+    folder = ml_images_root / "UPMC-Food101"
+    images = _take_subset(_list_images(folder), max_images)
+    if not images:
+        pytest.skip(f"No images found in {folder}")
+
+    print(f"[SERVICE] General foods folder: {folder} | images={len(images)}")
+
+    success_true = 0
+    with app.app_context():
+        for image_path in images:
+            result = predict_food(str(image_path))
+            _log_prediction("SERVICE", image_path, result)
+            _assert_common_fields(result)
+
+            if result["success"] is True:
+                success_true += 1
+                assert "food_name" in result, f"Missing food_name for {image_path}"
+                assert "calories" in result, f"Missing calories for {image_path}"
+            else:
+                assert (
+                    result.get("reason") == "low_confidence"
+                ), f"Expected low_confidence for {image_path} but got {result}"
+                assert "message" in result, f"Missing message for {image_path}"
+
+    print(f"[SERVICE] Accepted (success=True): {success_true}/{len(images)}")
+    assert success_true >= 1

--- a/machine-learning/scripts/bulk_rename_file.py
+++ b/machine-learning/scripts/bulk_rename_file.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 import argparse
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -9,8 +10,12 @@ def main():
         default=r"C:\Chukwudubanyi\Code\cu-bytes\machine-learning\data\test_data\hey_chef_carleton",
         help="Folder containing images to rename",
     )
-    parser.add_argument("--start", type=int, default=1, help="Starting image number (X)")
-    parser.add_argument("--dry-run", action="store_true", help="Print changes without renaming")
+    parser.add_argument(
+        "--start", type=int, default=1, help="Starting image number (X)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print changes without renaming"
+    )
     args = parser.parse_args()
 
     folder = Path(args.folder)
@@ -38,6 +43,7 @@ def main():
         else:
             path.rename(target)
             print(f"Renamed: {path.name} -> {new_name}")
+
 
 if __name__ == "__main__":
     main()

--- a/machine-learning/scripts/bulk_rename_file.py
+++ b/machine-learning/scripts/bulk_rename_file.py
@@ -1,0 +1,43 @@
+# rename_images.py
+from pathlib import Path
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--folder",
+        default=r"C:\Chukwudubanyi\Code\cu-bytes\machine-learning\data\test_data\hey_chef_carleton",
+        help="Folder containing images to rename",
+    )
+    parser.add_argument("--start", type=int, default=1, help="Starting image number (X)")
+    parser.add_argument("--dry-run", action="store_true", help="Print changes without renaming")
+    args = parser.parse_args()
+
+    folder = Path(args.folder)
+    if not folder.exists():
+        raise SystemExit(f"Folder not found: {folder}")
+
+    files = [p for p in folder.iterdir() if p.is_file()]
+    files.sort(key=lambda p: p.name.lower())
+
+    base = "heychef"
+
+    for idx, path in enumerate(files, start=args.start):
+        ext = path.suffix  # includes the dot, e.g. ".jpg"
+        new_name = f"image{idx}_{base}{ext}"
+        target = folder / new_name
+
+        if path.name == new_name:
+            continue
+
+        if target.exists():
+            raise SystemExit(f"Target already exists, would overwrite: {target}")
+
+        if args.dry_run:
+            print(f"DRY: {path.name} -> {new_name}")
+        else:
+            path.rename(target)
+            print(f"Renamed: {path.name} -> {new_name}")
+
+if __name__ == "__main__":
+    main()

--- a/machine-learning/scripts/category_coverage.py
+++ b/machine-learning/scripts/category_coverage.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+from scripts.food_category_matcher import create_class_mapping, load_food_categories
+
+FOOD101_CLASSES_FILE = Path("data/food-101/meta/classes.txt")
+UEC_CLASSES_DIR = Path("data/UECFOOD256")
+
+THRESHOLD = 0.92
+
+food_categories = load_food_categories(Path("food_categories.json"))
+
+food101_classes = []
+with open(FOOD101_CLASSES_FILE, "r", encoding="utf-8") as f:
+    food101_classes = [line.strip() for line in f if line.strip()]
+
+uec_classes = [
+    d.name
+    for d in UEC_CLASSES_DIR.iterdir()
+    if d.is_dir() and not d.name.startswith(".")
+]
+
+mapping_101 = create_class_mapping(
+    food101_classes, food_categories, threshold=THRESHOLD
+)
+mapping_uec = create_class_mapping(
+    uec_classes, food_categories, threshold=THRESHOLD
+)
+
+covered_categories_101 = set(mapping_101.values())
+covered_categories_uec = set(mapping_uec.values())
+
+overlap_categories = covered_categories_101 & covered_categories_uec
+uec_only_categories = covered_categories_uec - covered_categories_101
+
+missing_from_food101 = sorted(set(food_categories) - covered_categories_101)
+
+print(f"Base categories (food_categories.json): {len(food_categories)}")
+print(f"Food-101 covered categories: {len(covered_categories_101)}")
+print(f"UEC-256 covered categories: {len(covered_categories_uec)}")
+print(f"Overlap (covered by both): {len(overlap_categories)}")
+print(f"UEC-only (not covered by Food-101): {len(uec_only_categories)}")
+print()
+
+print(f"Missing from Food-101 (for reference): {len(missing_from_food101)}")
+for c in missing_from_food101:
+    print(c)
+
+print()
+print("Overlap categories:")
+for c in sorted(overlap_categories):
+    print(c)
+
+print()
+print("UEC-only categories:")
+for c in sorted(uec_only_categories):
+    print(c)
+
+# Which UEC class folders to use when you want "UEC-only" add-on data.
+# Rule: include UEC class folders whose mapped base category is in uec_only_categories.
+uec_classes_include = sorted(
+    [
+        cls
+        for cls in uec_classes
+        if cls in mapping_uec and mapping_uec[cls] in uec_only_categories
+    ]
+)
+
+uec_classes_exclude = sorted(
+    [
+        cls
+        for cls in uec_classes
+        if cls in mapping_uec and mapping_uec[cls] in covered_categories_101
+    ]
+)
+
+uec_classes_unmapped = sorted(
+    [cls for cls in uec_classes if cls not in mapping_uec]
+)
+
+print()
+print(
+    f"UEC class folders to INCLUDE (mapped to UEC-only categories): {len(uec_classes_include)}"
+)
+for c in uec_classes_include:
+    print(c)
+
+print()
+print(
+    f"UEC class folders to EXCLUDE (mapped to categories already covered by Food-101): {len(uec_classes_exclude)}"
+)
+for c in uec_classes_exclude:
+    print(c)
+
+print()
+print(
+    f"UEC class folders UNMAPPED (no base-category match at threshold={THRESHOLD}): {len(uec_classes_unmapped)}"
+)
+for c in uec_classes_unmapped:
+    print(c)

--- a/machine-learning/scripts/category_coverage.py
+++ b/machine-learning/scripts/category_coverage.py
@@ -9,7 +9,8 @@ except ModuleNotFoundError:
 FOOD101_CLASSES_FILE = Path("data/food-101/meta/classes.txt")
 UEC_CLASSES_DIR = Path("data/UECFOOD256")
 
-THRESHOLD = 0.92
+# controls name matching between food-101 and UECFOOD256
+THRESHOLD = 1
 
 food_categories = load_food_categories(Path("food_categories.json"))
 
@@ -34,70 +35,41 @@ covered_categories_101 = set(mapping_101.values())
 covered_categories_uec = set(mapping_uec.values())
 
 overlap_categories = covered_categories_101 & covered_categories_uec
-uec_only_categories = covered_categories_uec - covered_categories_101
+covered_by_any_dataset = covered_categories_101 | covered_categories_uec
 
-missing_from_food101 = sorted(set(food_categories) - covered_categories_101)
+base_categories_not_added = sorted(set(food_categories) - covered_by_any_dataset)
 
-print(f"Base categories (food_categories.json): {len(food_categories)}")
+
+def print_section(title: str):
+    bar = "=" * 80
+    print()
+    print(bar)
+    print(title)
+    print(bar)
+
+print_section("SUMMARY")
+print(f"Base categories: {len(food_categories)}")
 print(f"Food-101 covered categories: {len(covered_categories_101)}")
 print(f"UEC-256 covered categories: {len(covered_categories_uec)}")
-print(f"Overlap (covered by both): {len(overlap_categories)}")
-print(f"UEC-only (not covered by Food-101): {len(uec_only_categories)}")
-print()
+print(f"Overlap between Food-101 and UEC-256: {len(overlap_categories)}")
+print(f"Base categories not added by either: {len(base_categories_not_added)}")
 
-print(f"Missing from Food-101 (for reference): {len(missing_from_food101)}")
-for c in missing_from_food101:
+print_section(f"BASE CATEGORIES ({len(food_categories)})")
+for c in sorted(food_categories):
     print(c)
 
-print()
-print("Overlap categories:")
+print_section(f"FOOD-101 COVERED CATEGORIES ({len(covered_categories_101)})")
+for c in sorted(covered_categories_101):
+    print(c)
+
+print_section(f"UEC-256 COVERED CATEGORIES ({len(covered_categories_uec)})")
+for c in sorted(covered_categories_uec):
+    print(c)
+
+print_section(f"OVERLAP BETWEEN FOOD-101 AND UEC-256 ({len(overlap_categories)})")
 for c in sorted(overlap_categories):
     print(c)
 
-print()
-print("UEC-only categories:")
-for c in sorted(uec_only_categories):
-    print(c)
-
-# Which UEC class folders to use when you want "UEC-only" add-on data.
-# Rule: include UEC class folders whose mapped base category is in uec_only_categories.
-uec_classes_include = sorted(
-    [
-        cls
-        for cls in uec_classes
-        if cls in mapping_uec and mapping_uec[cls] in uec_only_categories
-    ]
-)
-
-uec_classes_exclude = sorted(
-    [
-        cls
-        for cls in uec_classes
-        if cls in mapping_uec and mapping_uec[cls] in covered_categories_101
-    ]
-)
-
-uec_classes_unmapped = sorted(
-    [cls for cls in uec_classes if cls not in mapping_uec]
-)
-
-print()
-print(
-    f"UEC class folders to INCLUDE (mapped to UEC-only categories): {len(uec_classes_include)}"
-)
-for c in uec_classes_include:
-    print(c)
-
-print()
-print(
-    f"UEC class folders to EXCLUDE (mapped to categories already covered by Food-101): {len(uec_classes_exclude)}"
-)
-for c in uec_classes_exclude:
-    print(c)
-
-print()
-print(
-    f"UEC class folders UNMAPPED (no base-category match at threshold={THRESHOLD}): {len(uec_classes_unmapped)}"
-)
-for c in uec_classes_unmapped:
+print_section(f"BASE CATEGORIES NOT ADDED BY EITHER ({len(base_categories_not_added)})")
+for c in sorted(base_categories_not_added):
     print(c)

--- a/machine-learning/scripts/category_coverage.py
+++ b/machine-learning/scripts/category_coverage.py
@@ -1,5 +1,10 @@
 from pathlib import Path
-from scripts.food_category_matcher import create_class_mapping, load_food_categories
+try:
+    # When running from the machine-learning folder with `python -m scripts.category_coverage`
+    from scripts.food_category_matcher import create_class_mapping, load_food_categories
+except ModuleNotFoundError:
+    # When running the file directly with `python scripts/category_coverage.py`
+    from food_category_matcher import create_class_mapping, load_food_categories
 
 FOOD101_CLASSES_FILE = Path("data/food-101/meta/classes.txt")
 UEC_CLASSES_DIR = Path("data/UECFOOD256")


### PR DESCRIPTION
# Description

Add two ML prediction tests using shared evaluation images to validate both model behavior and API integration.

- `backend/tests/test_ml_predict_service.py` tests predict_food() directly (function-level, no HTTP) across Carleton-specific food, non-food, and general-food image sets.
    - Verifies prediction response (success, confidence from 0-100)
    - Checks expected behavior by scenario (food accepted vs non-food low-confidence rejection ratio)
- `backend/tests/test_ml_predict_endpoint.py` tests POST /ml/predict end-to-end (upload -> endpoint -> service -> JSON response) over the same datasets.
    - Confirms POST /ml/predict accepts an image upload and correctly processes the full flow (upload -> prediction -> response) by returning the expected HTTP status and JSON fields (success, confidence, and either food_name or low_confidence reason/message)

## Test Failures
-  Both tests will fail unless at least 70% of the non-food images are rejected as low-confidence
- `test_ml_predict_service.py` fails if `predict_food(`) crashes, returns malformed output (missing success/confidence or bad confidence range), or food sets produce zero accepted predictions.
- `test_ml_predict_endpoint.py` fails if POST /ml/predict upload pipeline breaks (non-200 for valid image), endpoint returns malformed JSON, or food sets produce zero accepted predictions

Both tests share test images from the `machine-learning/data/evaluation_data` folder. The test images cover 3 scenarios:
- Food images from Hey Chef for Carleton University (65 in total)
- Non food images from the [Kaggle Food5k dataset](https://www.kaggle.com/datasets/trolukovich/food5k-image-dataset?select=evaluation) (100 in total)
- 20 generic food categories from the  [Kaggle UPMC Food-101](https://www.kaggle.com/datasets/gianmarco96/upmcfood101/data).  (100 in total)
    - The 20 categories are:
        - Pizza
        - Pho 
        - Pancakes
        - Pad thai
        - Onion rings
        - Grilled salmon
        - Hamburger
        - Nachos
        - Omelette
        - Fried rice
        - Salad (this was taken from [Food-11](https://www.kaggle.com/datasets/trolukovich/food11-image-dataset))
        - French fries
        - Hot dog
        - Mac and cheese
        - Donuts
        - Chicken wings
        - Sushi
        - Shawarma plate (Google images)
        - Shawarma (Google images)

**[Download the evaluation_data](https://drive.google.com/drive/folders/1920qpyP30fDyLUfwzylKZCEsUN7McVMU?usp=drive_link)** and add it to your `machine-learning/data/evaluation_data` folder.

- `ML_TEST_MAX_IMAGES` to cap number of images per folder (default currently 100)
- `ML_TEST_NONFOOD_MIN_LOW_CONF_RATIO` to enforce minimum rejection ratio for non-food images (default 0.7)
   

Fixes #156 
@Indecisive613 sorry but the ml tests increase your test cases time by like 20 seconds 😬
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests
- [ ] Manual tests
- [x] Linted/formatted

From the repository root:
- Run all tests using the command `python -m pytest backend/tests -v`
- Run each test individually using the following commands:
    - `python -m pytest backend/tests/test_ml_predict_service.py -s -vv`
    - `python -m pytest backend/tests/test_ml_predict_endpoint.py -s -vv`
## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
