### PR TITLE
Feature/frontend add sulfites and notes

### DIFF
--- a/frontend/cu-bytes/app/_context.tsx
+++ b/frontend/cu-bytes/app/_context.tsx
@@ -12,12 +12,14 @@ type UserContextType = {
     setHasConfiguredSettingsGlobal: (hasConfiguredSettingsGlobal: boolean) => void;
     showStatsGlobal: boolean;
     setShowStatsGlobal: (showStatsGlobal: boolean) => void;
+    hasDairyIntoleranceGlobal: boolean;
+    setHasDairyIntoleranceGlobal: (hasDairyIntoleranceGlobal: boolean) => void;    
     hasEggAllergyGlobal: boolean;
     setHasEggAllergyGlobal: (hasEggAllergyGlobal: boolean) => void;
     hasFishOrShellfishAllergyGlobal: boolean; 
     setHasFishOrShellfishAllergyGlobal: (hasFishOrShellfishAllergyGlobal: boolean) => void;
-    hasDairyIntoleranceGlobal: boolean;
-    setHasDairyIntoleranceGlobal: (hasDairyIntoleranceGlobal: boolean) => void;
+    hasGlutenAllergyGlobal: boolean;
+    setHasGlutenAllergyGlobal: (hasGlutenAllergyGlobal: boolean) => void;        
     hasMilkAllergyGlobal: boolean;
     setHasMilkAllergyGlobal: (hasMilkAllergyGlobal: boolean) => void;
     hasPeanutAllergyGlobal: boolean;
@@ -26,12 +28,12 @@ type UserContextType = {
     setHasSesameAllergyGlobal: (HasSesameAllergyGlobal: boolean) => void;
     hasSoyAllergyGlobal: boolean;
     setHasSoyAllergyGlobal: (hasSoyAllergyGlobal: boolean) => void;
+    hasSulfitesAllergyGlobal: boolean;
+    setHasSulfitesAllergyGlobal: (hasSulfitesAllergyGlobal: boolean) => void;
     hasTreenutAllergyGlobal: boolean;
     setHasTreenutAllergyGlobal: (hasTreenutAllergyGlobal: boolean) => void;
     hasWheatAllergyGlobal: boolean;
     setHasWheatAllergyGlobal: (hasWheatAllergyGlobal: boolean) => void;
-    hasGlutenAllergyGlobal: boolean;
-    setHasGlutenAllergyGlobal: (hasGlutenAllergyGlobal: boolean) => void;
     isVeganGlobal: boolean;
     setIsVeganGlobal: (isVeganGlobal: boolean) => void;
     isVegetarianGlobal: boolean;
@@ -53,16 +55,17 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
     const [usernameGlobal, setUsernameGlobal] = useState('');
     const [hasConfiguredSettingsGlobal, setHasConfiguredSettingsGlobal] = useState(false); 
     const [showStatsGlobal, setShowStatsGlobal] = useState(false);
+    const [hasDairyIntoleranceGlobal, setHasDairyIntoleranceGlobal] = useState(false);
     const [hasEggAllergyGlobal, setHasEggAllergyGlobal] = useState(false);
     const [hasFishOrShellfishAllergyGlobal, setHasFishOrShellfishAllergyGlobal] = useState(false);
-    const [hasDairyIntoleranceGlobal, setHasDairyIntoleranceGlobal] = useState(false);
+    const [hasGlutenAllergyGlobal, setHasGlutenAllergyGlobal] = useState(false);
     const [hasMilkAllergyGlobal, setHasMilkAllergyGlobal] = useState(false);
     const [hasPeanutAllergyGlobal, setHasPeanutAllergyGlobal] = useState(false);
     const [hasSesameAllergyGlobal, setHasSesameAllergyGlobal] = useState(false);
     const [hasSoyAllergyGlobal, setHasSoyAllergyGlobal] = useState(false);
+    const [hasSulfitesAllergyGlobal, setHasSulfitesAllergyGlobal] = useState(false);
     const [hasTreenutAllergyGlobal, setHasTreenutAllergyGlobal] = useState(false);
     const [hasWheatAllergyGlobal, setHasWheatAllergyGlobal] = useState(false);
-    const [hasGlutenAllergyGlobal, setHasGlutenAllergyGlobal] = useState(false);
     const [isVeganGlobal, setIsVeganGlobal] = useState(false);
     const [isVegetarianGlobal, setIsVegetarianGlobal] = useState(false);
     const [prefersHalalGlobal, setPrefersHalalGlobal] = useState(false);
@@ -77,12 +80,14 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
                     setHasConfiguredSettingsGlobal,
                     showStatsGlobal,
                     setShowStatsGlobal,
+                    hasDairyIntoleranceGlobal,
+                    setHasDairyIntoleranceGlobal,
                     hasEggAllergyGlobal,
                     setHasEggAllergyGlobal,
                     hasFishOrShellfishAllergyGlobal,
                     setHasFishOrShellfishAllergyGlobal,
-                    hasDairyIntoleranceGlobal,
-                    setHasDairyIntoleranceGlobal,
+                    hasGlutenAllergyGlobal,
+                    setHasGlutenAllergyGlobal,
                     hasMilkAllergyGlobal,
                     setHasMilkAllergyGlobal,
                     hasPeanutAllergyGlobal,
@@ -91,12 +96,12 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
                     setHasSesameAllergyGlobal,
                     hasSoyAllergyGlobal,
                     setHasSoyAllergyGlobal,
+                    hasSulfitesAllergyGlobal,
+                    setHasSulfitesAllergyGlobal,
                     hasTreenutAllergyGlobal,
                     setHasTreenutAllergyGlobal,
                     hasWheatAllergyGlobal,
                     setHasWheatAllergyGlobal,
-                    hasGlutenAllergyGlobal,
-                    setHasGlutenAllergyGlobal,
                     isVeganGlobal,
                     setIsVeganGlobal,
                     isVegetarianGlobal,

--- a/frontend/cu-bytes/app/_layout.tsx
+++ b/frontend/cu-bytes/app/_layout.tsx
@@ -8,13 +8,17 @@ export default function RootLayout() {
       <Stack
         screenOptions={ { headerShown: false }}
       >
-        <Stack.Screen name="index"/>
+        <Stack.Screen name="dining"/>
+        <Stack.Screen name="enter"/>        
+        <Stack.Screen name="entries"/>
         <Stack.Screen name="home"/>
+        <Stack.Screen name="index"/>
         <Stack.Screen name="login"/>
+        <Stack.Screen name="recommendations"/>        
         <Stack.Screen name="register"/>
+        <Stack.Screen name="scan"/>        
         <Stack.Screen name="settings"/>
-        <Stack.Screen name="enter"/>
-        <Stack.Screen name="scan"/>
+        <Stack.Screen name="statistics"/>
       </Stack>
     </UserProvider>
   );

--- a/frontend/cu-bytes/app/_styles/style-home.tsx
+++ b/frontend/cu-bytes/app/_styles/style-home.tsx
@@ -172,7 +172,7 @@ export const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     color: '#FFFFFF',
     fontFamily: 'arial',
-    fontSize: font(175),
+    fontSize: font(150),
     fontWeight: 'bold',
     textAlign: 'center',
   },

--- a/frontend/cu-bytes/app/_styles/style-home.tsx
+++ b/frontend/cu-bytes/app/_styles/style-home.tsx
@@ -175,34 +175,6 @@ export const styles = StyleSheet.create({
     fontSize: font(150),
     fontWeight: 'bold',
     textAlign: 'center',
-  },
-
-  bodyButtonAlt: {
-    alignItems: 'center',
-    backgroundColor: '#131312',
-    borderRadius: 20,
-    borderWidth: 4,
-    borderColor: '#666666',
-    height: h(15),
-    justifyContent: 'center',
-    marginTop: h(1.0),
-    marginBottom: h(1.0),
-    marginLeft: w(0.5),
-    marginRight: w(0.5),
-    paddingTop: h(2.0),
-    paddingBottom: h(2.0),
-    paddingLeft: w(2.0),
-    paddingRight: w(2.0),
-    width: w(80),
-  },
-
-  bodyButtonTextAlt: {
-    backgroundColor: 'transparent',
-    color: '#C5151A',
-    fontFamily: 'arial',
-    fontSize: font(175),
-    fontWeight: 'bold',
-    textAlign: 'center',
   }
 
 });

--- a/frontend/cu-bytes/app/_styles/style-index.tsx
+++ b/frontend/cu-bytes/app/_styles/style-index.tsx
@@ -106,34 +106,6 @@ export const styles = StyleSheet.create({
     fontSize: font(175),
     fontWeight: 'bold',
     textAlign: 'center',
-  },
-
-  bodyButtonAlt: {
-    alignItems: 'center',
-    backgroundColor: '#131312',
-    borderRadius: 20,
-    borderWidth: 4,
-    borderColor: '#666666',
-    height: h(15),
-    justifyContent: 'center',
-    marginTop: h(1.0),
-    marginBottom: h(1.0),
-    marginLeft: w(0.5),
-    marginRight: w(0.5),
-    paddingTop: h(2.0),
-    paddingBottom: h(2.0),
-    paddingLeft: w(2.0),
-    paddingRight: w(2.0),
-    width: w(80),
-  },
-
-  bodyButtonTextAlt: {
-    backgroundColor: 'transparent',
-    color: '#C5151A',
-    fontFamily: 'arial',
-    fontSize: font(175),
-    fontWeight: 'bold',
-    textAlign: 'center',
   }
 
 });

--- a/frontend/cu-bytes/app/dining.tsx
+++ b/frontend/cu-bytes/app/dining.tsx
@@ -398,6 +398,31 @@ export default function DiningScreen() {
     }
 
     /*
+        If the user is not logged-in, set the profile settings to true,
+        So that all allergy and intolerance warnings will be displayed by default
+    */
+    useEffect(() => {
+        
+        if (usernameGlobal === '') {
+            setHasDairyIntoleranceGlobal(true);
+            setHasEggAllergyGlobal(true);
+            setHasFishOrShellfishAllergyGlobal(true);
+            setHasGlutenAllergyGlobal(true);
+            setHasMilkAllergyGlobal(true);
+            setHasPeanutAllergyGlobal(true);
+            setHasSesameAllergyGlobal(true);
+            setHasSulfitesAllergyGlobal(true);
+            setHasSoyAllergyGlobal(true);
+            setHasTreenutAllergyGlobal(true);
+            setHasWheatAllergyGlobal(true);
+            setIsVeganGlobal(true);
+            setIsVegetarianGlobal(true);
+            setPrefersHalalGlobal(true);
+        }
+
+    }, []);
+
+    /*
         Send a request to the backend endpoint to get all food items from the database
     */
     useEffect(() => {

--- a/frontend/cu-bytes/app/dining.tsx
+++ b/frontend/cu-bytes/app/dining.tsx
@@ -24,31 +24,32 @@ export default function DiningScreen() {
     const
         {
             usernameGlobal,
+            hasDairyIntoleranceGlobal,            
             hasEggAllergyGlobal,
             hasFishOrShellfishAllergyGlobal,
-            hasDairyIntoleranceGlobal,
+            hasGlutenAllergyGlobal,            
             hasMilkAllergyGlobal,
             hasPeanutAllergyGlobal,
             hasSesameAllergyGlobal,
+            hasSulfitesAllergyGlobal,
             hasSoyAllergyGlobal,
             hasTreenutAllergyGlobal,
             hasWheatAllergyGlobal,
-            hasGlutenAllergyGlobal,
             isVeganGlobal,
             isVegetarianGlobal,
             prefersHalalGlobal,
             setUsernameGlobal,
-            setShowStatsGlobal,
+            setHasDairyIntoleranceGlobal,            
             setHasEggAllergyGlobal,
             setHasFishOrShellfishAllergyGlobal,
-            setHasDairyIntoleranceGlobal,
+            setHasGlutenAllergyGlobal,
             setHasMilkAllergyGlobal,
             setHasPeanutAllergyGlobal,
             setHasSesameAllergyGlobal,
+            setHasSulfitesAllergyGlobal,
             setHasSoyAllergyGlobal,
             setHasTreenutAllergyGlobal,
             setHasWheatAllergyGlobal,
-            setHasGlutenAllergyGlobal,
             setIsVeganGlobal,
             setIsVegetarianGlobal,
             setPrefersHalalGlobal
@@ -76,6 +77,7 @@ export default function DiningScreen() {
             has_peanuts: null,
             has_sesame: null,
             has_soy: null,
+            has_sulfites: null,
             has_treenuts: null,
             has_wheat: null,
             id: -1, // Initial value of 1 to prevent errors
@@ -103,6 +105,7 @@ export default function DiningScreen() {
             has_peanuts: null,
             has_sesame: null,
             has_soy: null,
+            has_sulfites: null,
             has_treenuts: null,
             has_wheat: null,
             id: number,
@@ -312,84 +315,78 @@ export default function DiningScreen() {
         if (foodItem["has_eggs"] === null && hasEggAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain eggs" });
         }
-
         if (foodItem["has_fish_or_shellfish"] === true && hasFishOrShellfishAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains fish or shellfish" });
         }
         if (foodItem["has_fish_or_shellfish"] === null && hasFishOrShellfishAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain fish or shellfish" });
         }
-
         if (foodItem["is_dairy_free"] === false && hasDairyIntoleranceGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains dairy" });
         }
         if (foodItem["is_dairy_free"] === null && hasDairyIntoleranceGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain dairy" });
         }
-
         if (foodItem["has_milk"] === true && hasMilkAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains milk" });
         }
         if (foodItem["has_milk"] === null && hasMilkAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain milk" });
         }
-
         if (foodItem["has_peanuts"] === true && hasPeanutAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains peanuts" });
         }
         if (foodItem["has_peanuts"] === null && hasPeanutAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain peanuts" });
         }
-
         if (foodItem["has_sesame"] === true && hasSesameAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains sesame" });
         }
         if (foodItem["has_sesame"] === null && hasSesameAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain sesame" });
         }
-        
         if (foodItem["has_soy"] === true && hasSoyAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains soy" });
         }
         if (foodItem["has_soy"] === null && hasSoyAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain soy" });
         }
-
+        if (foodItem["has_sulfites"] === true && hasSulfitesAllergyGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains sulfites" });
+        }
+        if (foodItem["has_sulfites"] === null && hasSulfitesAllergyGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain sulfites" });
+        }
         if (foodItem["has_treenuts"] === true && hasTreenutAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains treenuts" });
         }
         if (foodItem["has_treenuts"] === null && hasTreenutAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain treenuts" });
         }
-
         if (foodItem["has_wheat"] === true && hasWheatAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains wheat" });
         }
         if (foodItem["has_wheat"] === null && hasWheatAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain wheat" });
         }
-
         if (foodItem["is_gluten_free"] === false && hasGlutenAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains gluten" });
         }
         if (foodItem["is_gluten_free"] === null && hasGlutenAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain gluten" });
         }
-
         if (foodItem["is_vegan"] === false && isVeganGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item is not vegan" });
         }
         if (foodItem["is_vegan"] === null && isVeganGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may not be vegan" });
         }
-
         if (foodItem["is_vegetarian"] === false && isVegetarianGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item is not vegetarian" });
         }
         if (foodItem["is_vegetarian"] === null && isVegetarianGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may not be vegetarian" });
         }
-
         if (foodItem["is_halal"] === false && prefersHalalGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item is not halal" });
         }
@@ -548,22 +545,22 @@ export default function DiningScreen() {
     }
 
     /*
-        Log out the logged-in user by setting their username and profile settings to null, and routing to the splash page
+        Log out the logged-in user by setting their profile settings to false, and routing to the splash page
     */
     const logout = () => { 
         
         setUsernameGlobal('');
-        setShowStatsGlobal(false);
+        setHasDairyIntoleranceGlobal(false);        
         setHasEggAllergyGlobal(false);
         setHasFishOrShellfishAllergyGlobal(false);
-        setHasDairyIntoleranceGlobal(false);
+        setHasGlutenAllergyGlobal(false);
         setHasMilkAllergyGlobal(false);
         setHasPeanutAllergyGlobal(false);
         setHasSesameAllergyGlobal(false);
         setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergyGlobal(false);
         setHasTreenutAllergyGlobal(false);
         setHasWheatAllergyGlobal(false);
-        setHasGlutenAllergyGlobal(false);
         setIsVeganGlobal(false);
         setIsVegetarianGlobal(false);
         setPrefersHalalGlobal(false);

--- a/frontend/cu-bytes/app/dining.tsx
+++ b/frontend/cu-bytes/app/dining.tsx
@@ -14,7 +14,7 @@ export default function DiningScreen() {
     const [diningLocationsVisible, setDiningLocationsVisible] = useState(true);
     const [foodItemsVisible, setFoodItemsVisible] = useState(true);
     const [modalVisible, setModalVisible] = useState(false);
-    const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
     const [isSearchPressed, setIsSearchPressed] = useState(false);
 
@@ -591,14 +591,14 @@ export default function DiningScreen() {
             <View id="browseDiningLocationsStatusbar" style={styles.statusbar}>
 
                 {/* Route the user to the 'home' page or the 'splash' page */}
-                <TouchableOpacity id="backButton"
-                    style={[styles.headerButtonDefault, {backgroundColor: isBackPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBackPressed(true)}
-                    onPressOut={() => setIsBackPressed(false)}
+                <TouchableOpacity id="homeOrSplashButton"
+                    style={[styles.headerButtonDefault, {backgroundColor: isHomeOrSplashPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsHomeOrSplashPressed(true)}
+                    onPressOut={() => setIsHomeOrSplashPressed(false)}
                     onPress={() => usernameGlobal != '' ? router.push('/home') : router.push('/')}>
 
-                    <Text id="backButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
-                        Back
+                    <Text id="homeOrSplashButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
+                        Home
                     </Text>
                 </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/enter.tsx
+++ b/frontend/cu-bytes/app/enter.tsx
@@ -402,6 +402,31 @@ export default function EnterScreen() {
     }
 
     /*
+        If the user is not logged-in, set the profile settings to true,
+        So that all allergy and intolerance warnings will be displayed by default
+    */
+    useEffect(() => {
+        
+        if (usernameGlobal === '') {
+            setHasDairyIntoleranceGlobal(true);
+            setHasEggAllergyGlobal(true);
+            setHasFishOrShellfishAllergyGlobal(true);
+            setHasGlutenAllergyGlobal(true);
+            setHasMilkAllergyGlobal(true);
+            setHasPeanutAllergyGlobal(true);
+            setHasSesameAllergyGlobal(true);
+            setHasSulfitesAllergyGlobal(true);
+            setHasSoyAllergyGlobal(true);
+            setHasTreenutAllergyGlobal(true);
+            setHasWheatAllergyGlobal(true);
+            setIsVeganGlobal(true);
+            setIsVegetarianGlobal(true);
+            setPrefersHalalGlobal(true);
+        }
+
+    }, []);
+
+    /*
         Send a request to the backend endpoint to get all food items from the database
     */
     useEffect(() => {

--- a/frontend/cu-bytes/app/enter.tsx
+++ b/frontend/cu-bytes/app/enter.tsx
@@ -23,31 +23,32 @@ export default function EnterScreen() {
     const 
         {
             usernameGlobal,
+            hasDairyIntoleranceGlobal,            
             hasEggAllergyGlobal,
             hasFishOrShellfishAllergyGlobal,
-            hasDairyIntoleranceGlobal,
+            hasGlutenAllergyGlobal,            
             hasMilkAllergyGlobal,
             hasPeanutAllergyGlobal,
             hasSesameAllergyGlobal,
+            hasSulfitesAllergyGlobal,
             hasSoyAllergyGlobal,
             hasTreenutAllergyGlobal,
             hasWheatAllergyGlobal,
-            hasGlutenAllergyGlobal,
             isVeganGlobal,
             isVegetarianGlobal,
             prefersHalalGlobal,
             setUsernameGlobal,
-            setShowStatsGlobal,
+            setHasDairyIntoleranceGlobal,            
             setHasEggAllergyGlobal,
             setHasFishOrShellfishAllergyGlobal,
-            setHasDairyIntoleranceGlobal,
+            setHasGlutenAllergyGlobal,
             setHasMilkAllergyGlobal,
             setHasPeanutAllergyGlobal,
             setHasSesameAllergyGlobal,
+            setHasSulfitesAllergyGlobal,
             setHasSoyAllergyGlobal,
             setHasTreenutAllergyGlobal,
             setHasWheatAllergyGlobal,
-            setHasGlutenAllergyGlobal,
             setIsVeganGlobal,
             setIsVegetarianGlobal,
             setPrefersHalalGlobal
@@ -75,6 +76,7 @@ export default function EnterScreen() {
             has_peanuts: null,
             has_sesame: null,
             has_soy: null,
+            has_sulfites: null,
             has_treenuts: null,
             has_wheat: null,
             id: -1, // Initial value of 1 to prevent errors
@@ -102,6 +104,7 @@ export default function EnterScreen() {
             has_peanuts: null,
             has_sesame: null,
             has_soy: null,
+            has_sulfites: null,
             has_treenuts: null,
             has_wheat: null,
             id: number,
@@ -316,84 +319,78 @@ export default function EnterScreen() {
         if (foodItem["has_eggs"] === null && hasEggAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain eggs" });
         }
-
         if (foodItem["has_fish_or_shellfish"] === true && hasFishOrShellfishAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains fish or shellfish" });
         }
         if (foodItem["has_fish_or_shellfish"] === null && hasFishOrShellfishAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain fish or shellfish" });
         }
-
         if (foodItem["is_dairy_free"] === false && hasDairyIntoleranceGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains dairy" });
         }
         if (foodItem["is_dairy_free"] === null && hasDairyIntoleranceGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain dairy" });
         }
-
         if (foodItem["has_milk"] === true && hasMilkAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains milk" });
         }
         if (foodItem["has_milk"] === null && hasMilkAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain milk" });
         }
-
         if (foodItem["has_peanuts"] === true && hasPeanutAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains peanuts" });
         }
         if (foodItem["has_peanuts"] === null && hasPeanutAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain peanuts" });
         }
-
         if (foodItem["has_sesame"] === true && hasSesameAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains sesame" });
         }
         if (foodItem["has_sesame"] === null && hasSesameAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain sesame" });
         }
-        
         if (foodItem["has_soy"] === true && hasSoyAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains soy" });
         }
         if (foodItem["has_soy"] === null && hasSoyAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain soy" });
         }
-
+        if (foodItem["has_sulfites"] === true && hasSulfitesAllergyGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains sulfites" });
+        }
+        if (foodItem["has_sulfites"] === null && hasSulfitesAllergyGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain sulfites" });
+        }
         if (foodItem["has_treenuts"] === true && hasTreenutAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains treenuts" });
         }
         if (foodItem["has_treenuts"] === null && hasTreenutAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain treenuts" });
         }
-
         if (foodItem["has_wheat"] === true && hasWheatAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains wheat" });
         }
         if (foodItem["has_wheat"] === null && hasWheatAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain wheat" });
         }
-
         if (foodItem["is_gluten_free"] === false && hasGlutenAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains gluten" });
         }
         if (foodItem["is_gluten_free"] === null && hasGlutenAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain gluten" });
         }
-
         if (foodItem["is_vegan"] === false && isVeganGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item is not vegan" });
         }
         if (foodItem["is_vegan"] === null && isVeganGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may not be vegan" });
         }
-
         if (foodItem["is_vegetarian"] === false && isVegetarianGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item is not vegetarian" });
         }
         if (foodItem["is_vegetarian"] === null && isVegetarianGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may not be vegetarian" });
         }
-
         if (foodItem["is_halal"] === false && prefersHalalGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item is not halal" });
         }
@@ -487,22 +484,22 @@ export default function EnterScreen() {
     }
 
     /*
-        Log out the logged-in user by setting their username and profile settings to null, and routing to the splash page
+        Log out the logged-in user by setting their profile settings to false, and routing to the splash page
     */
     const logout = () => { 
         
         setUsernameGlobal('');
-        setShowStatsGlobal(false);
+        setHasDairyIntoleranceGlobal(false);        
         setHasEggAllergyGlobal(false);
         setHasFishOrShellfishAllergyGlobal(false);
-        setHasDairyIntoleranceGlobal(false);
+        setHasGlutenAllergyGlobal(false);
         setHasMilkAllergyGlobal(false);
         setHasPeanutAllergyGlobal(false);
         setHasSesameAllergyGlobal(false);
         setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergyGlobal(false);
         setHasTreenutAllergyGlobal(false);
         setHasWheatAllergyGlobal(false);
-        setHasGlutenAllergyGlobal(false);
         setIsVeganGlobal(false);
         setIsVegetarianGlobal(false);
         setPrefersHalalGlobal(false);

--- a/frontend/cu-bytes/app/enter.tsx
+++ b/frontend/cu-bytes/app/enter.tsx
@@ -13,7 +13,7 @@ export default function EnterScreen() {
     const [loading, setLoading] = useState(true);
     const [visible, setVisible] = useState(false);
     const [modalVisible, setModalVisible] = useState(false);
-    const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
     const [isSearchPressed, setIsSearchPressed] = useState(false);
 
@@ -530,14 +530,14 @@ export default function EnterScreen() {
             <View id="browseFoodItemsStatusbar" style={styles.statusbar}>
 
                 {/* Route the user to the 'home' page or the 'splash' page */}
-                <TouchableOpacity id="backButton"
-                    style={[styles.headerButtonDefault, {backgroundColor: isBackPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBackPressed(true)}
-                    onPressOut={() => setIsBackPressed(false)}
+                <TouchableOpacity id="homeOrSplashButton"
+                    style={[styles.headerButtonDefault, {backgroundColor: isHomeOrSplashPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsHomeOrSplashPressed(true)}
+                    onPressOut={() => setIsHomeOrSplashPressed(false)}
                     onPress={() => usernameGlobal != '' ? router.push('/home') : router.push('/')}>
 
-                    <Text id="backButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
-                        Back
+                    <Text id="homeOrSplashButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
+                        Home
                     </Text>     
                 </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/entries.tsx
+++ b/frontend/cu-bytes/app/entries.tsx
@@ -22,17 +22,17 @@ export default function EntriesScreen() {
         {
             usernameGlobal,
             setUsernameGlobal,
-            setShowStatsGlobal,
+            setHasDairyIntoleranceGlobal,            
             setHasEggAllergyGlobal,
             setHasFishOrShellfishAllergyGlobal,
-            setHasDairyIntoleranceGlobal,
+            setHasGlutenAllergyGlobal,
             setHasMilkAllergyGlobal,
             setHasPeanutAllergyGlobal,
             setHasSesameAllergyGlobal,
+            setHasSulfitesAllergyGlobal,
             setHasSoyAllergyGlobal,
             setHasTreenutAllergyGlobal,
             setHasWheatAllergyGlobal,
-            setHasGlutenAllergyGlobal,
             setIsVeganGlobal,
             setIsVegetarianGlobal,
             setPrefersHalalGlobal
@@ -188,22 +188,22 @@ export default function EntriesScreen() {
    }
 
     /*
-        Log out the logged-in user by setting their username and profile settings to null, and routing to the splash page
+        Log out the logged-in user by setting their profile settings to false, and routing to the splash page
     */
     const logout = () => { 
         
         setUsernameGlobal('');
-        setShowStatsGlobal(false);
+        setHasDairyIntoleranceGlobal(false);        
         setHasEggAllergyGlobal(false);
         setHasFishOrShellfishAllergyGlobal(false);
-        setHasDairyIntoleranceGlobal(false);
+        setHasGlutenAllergyGlobal(false);
         setHasMilkAllergyGlobal(false);
         setHasPeanutAllergyGlobal(false);
         setHasSesameAllergyGlobal(false);
         setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergyGlobal(false);
         setHasTreenutAllergyGlobal(false);
         setHasWheatAllergyGlobal(false);
-        setHasGlutenAllergyGlobal(false);
         setIsVeganGlobal(false);
         setIsVegetarianGlobal(false);
         setPrefersHalalGlobal(false);

--- a/frontend/cu-bytes/app/entries.tsx
+++ b/frontend/cu-bytes/app/entries.tsx
@@ -12,7 +12,7 @@ export default function EntriesScreen() {
 
     const [loading, setLoading] = useState(true);
     const [visible, setVisible] = useState(false);
-    const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
 
     /*
@@ -220,14 +220,14 @@ export default function EntriesScreen() {
             <View id="viewSavedFoodItemsStatusbar" style={styles.statusbar}>
 
                 {/* Route the user to the 'home' page */}
-                <TouchableOpacity id="backButton"
-                    style={[styles.headerButtonDefault, {backgroundColor: isBackPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBackPressed(true)}
-                    onPressOut={() => setIsBackPressed(false)}
+                <TouchableOpacity id="homeOrSplashButton"
+                    style={[styles.headerButtonDefault, {backgroundColor: isHomeOrSplashPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsHomeOrSplashPressed(true)}
+                    onPressOut={() => setIsHomeOrSplashPressed(false)}
                     onPress={() => router.push('/home')}>
 
-                    <Text id="backButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
-                        Back
+                    <Text id="homeOrSplashButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
+                        Home
                     </Text>
                 </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/home.tsx
+++ b/frontend/cu-bytes/app/home.tsx
@@ -34,18 +34,18 @@ export default function HomeScreen() {
             usernameGlobal,
             hasConfiguredSettingsGlobal,
             setUsernameGlobal,
-            setShowStatsGlobal,
             setHasConfiguredSettingsGlobal,
+            setHasDairyIntoleranceGlobal,            
             setHasEggAllergyGlobal,
             setHasFishOrShellfishAllergyGlobal,
-            setHasDairyIntoleranceGlobal,
+            setHasGlutenAllergyGlobal,
             setHasMilkAllergyGlobal,
             setHasPeanutAllergyGlobal,
             setHasSesameAllergyGlobal,
+            setHasSulfitesAllergyGlobal,
             setHasSoyAllergyGlobal,
             setHasTreenutAllergyGlobal,
             setHasWheatAllergyGlobal,
-            setHasGlutenAllergyGlobal,
             setIsVeganGlobal,
             setIsVegetarianGlobal,
             setPrefersHalalGlobal
@@ -81,23 +81,23 @@ export default function HomeScreen() {
     }, []);
 
     /*
-        Log out the logged-in user by setting their username and profile settings to null, and routing to the splash page
+        Log out the logged-in user by setting their profile settings to false, and routing to the splash page
     */
     const logout = () => { 
         
         setUsernameGlobal('');
-        setShowStatsGlobal(false);
         setHasConfiguredSettingsGlobal(false);
+        setHasDairyIntoleranceGlobal(false);        
         setHasEggAllergyGlobal(false);
         setHasFishOrShellfishAllergyGlobal(false);
-        setHasDairyIntoleranceGlobal(false);
+        setHasGlutenAllergyGlobal(false);
         setHasMilkAllergyGlobal(false);
         setHasPeanutAllergyGlobal(false);
         setHasSesameAllergyGlobal(false);
         setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergyGlobal(false);
         setHasTreenutAllergyGlobal(false);
         setHasWheatAllergyGlobal(false);
-        setHasGlutenAllergyGlobal(false);
         setIsVeganGlobal(false);
         setIsVegetarianGlobal(false);
         setPrefersHalalGlobal(false);

--- a/frontend/cu-bytes/app/home.tsx
+++ b/frontend/cu-bytes/app/home.tsx
@@ -12,13 +12,16 @@ export default function HomeScreen() {
 
     const [loading, setLoading] = useState(false);
     const [modalVisible, setModalVisible] = useState(false);
+    const [browseButtons, setBrowseButtons] = useState(false);
     
     const [isSettingsPressed, setIsSettingsPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
 
     const [isScanFoodItemPressed, setIsScanFoodItemPressed] = useState(false);
+    const [isBrowsePressed, setIsBrowsePressed] = useState(false);
     const [isBrowseFoodItemsPressed, setIsBrowseFoodItemsPressed] = useState(false);
     const [isBrowseDiningLocationsPressed, setIsBrowseDiningLocationsPressed] = useState(false);
+    
     const [isViewSavedFoodItemsPressed, setIsViewSavedFoodItemsPressed] = useState(false);
     const [isStatisticsPressed, setIsStatisticsPressed] = useState(false);
     const [isRecommendationsPressed, setIsRecommendationsPressed] = useState(false)
@@ -112,10 +115,11 @@ export default function HomeScreen() {
 
                 {/* Route the user to the 'settings' page */}
                 <TouchableOpacity id="settingsButton"
-                    style={[styles.headerButtonDefault, {backgroundColor: isSettingsPressed ? '#666666' : '#131312'}]}
+                    style={[styles.headerButtonDefault, {backgroundColor: isSettingsPressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
                     onPressIn={() => setIsSettingsPressed(true)}
                     onPressOut={() => setIsSettingsPressed(false)}
-                    onPress={() => router.push("/settings")}>
+                    onPress={() => router.push("/settings")}
+                    disabled={usernameGlobal === '' ? true : false}>
                     
                     <Text id="settingsButtonText" style={styles.headerButtonTextDefault}>
                         Settings
@@ -173,83 +177,125 @@ export default function HomeScreen() {
                     What would you like to do?
                 </Text>
 
-                {/* Route the user to the 'scan food item' page */}
-                <TouchableOpacity id="scanFoodItemButton"
-                    style={[styles.bodyButtonDefault, {backgroundColor: isScanFoodItemPressed || usernameGlobal == '' ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsScanFoodItemPressed(true)}
-                    onPressOut={() => setIsScanFoodItemPressed(false)}
-                    onPress={() => router.push("/scan")}
-                    disabled={usernameGlobal == '' ? true : false}>
+                {/* Display buttons that are not related to browsing food items or browsing dining locations */}
+                {!browseButtons && (
+                    <View id="defaultButtonsView" style={styles.container}>
 
-                    <Text id="scanFoodItemButtonText" style={styles.bodyButtonTextDefault}>
-                        Scan Food
-                    </Text>
-                </TouchableOpacity>
+                        {/* Route the user to the 'scan food item' page */}
+                        <TouchableOpacity id="scanFoodItemButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isScanFoodItemPressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsScanFoodItemPressed(true)}
+                            onPressOut={() => setIsScanFoodItemPressed(false)}
+                            onPress={() => router.push("/scan")}
+                            disabled={usernameGlobal === '' ? true : false}>
 
-                {/* Route the user to the 'browse food items' page */}
-                <TouchableOpacity id="browseFoodItemsButton"
-                    style={[styles.bodyButtonDefault, {backgroundColor: isBrowseFoodItemsPressed || usernameGlobal == '' ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBrowseFoodItemsPressed(true)}
-                    onPressOut={() => setIsBrowseFoodItemsPressed(false)}
-                    onPress={() => router.push("/enter")}
-                    disabled={usernameGlobal == '' ? true : false}>
+                            <Text id="scanFoodItemButtonText" style={styles.bodyButtonTextDefault}>
+                                Scan Food
+                            </Text>
+                        </TouchableOpacity>
 
-                    <Text id="browseFoodItemsButtonText" style={styles.bodyButtonTextDefault}>
-                        Browse Food
-                    </Text>
-                </TouchableOpacity>
+                        {/* Route the user to the 'browse food items' page */}
+                        <TouchableOpacity id="browseButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isBrowsePressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsBrowseFoodItemsPressed(true)}
+                            onPressOut={() => setIsBrowseFoodItemsPressed(false)}
+                            onPress={() => setBrowseButtons(true)}
+                            disabled={usernameGlobal === '' ? true : false}>
 
-                {/* Route the user to the 'browse dining locations' page */}
-                <TouchableOpacity id="browseDiningLocationsButton"
-                    style={[styles.bodyButtonDefault, {backgroundColor: isBrowseDiningLocationsPressed || usernameGlobal == '' ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBrowseDiningLocationsPressed(true)}
-                    onPressOut={() => setIsBrowseDiningLocationsPressed(false)}
-                    onPress={() => router.push("/dining")}
-                    disabled={usernameGlobal == '' ? true : false}>
+                            <Text id="browseButtonText" style={styles.bodyButtonTextDefault}>
+                                Browse
+                            </Text>
+                        </TouchableOpacity>
 
-                    <Text id="browseDiningLocationsButtonText" style={styles.bodyButtonTextDefault}>
-                        Browse Dining
-                    </Text>
-                </TouchableOpacity>
+                        {/* Route the user to the 'view saved food items' page */}
+                        <TouchableOpacity id="viewSavedFoodItemsButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isViewSavedFoodItemsPressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsViewSavedFoodItemsPressed(true)}
+                            onPressOut={() => setIsViewSavedFoodItemsPressed(false)}
+                            onPress={() => router.push("/entries")}
+                            disabled={usernameGlobal === '' ? true : false}>
 
-                {/* Route the user to the 'view saved food items' page */}
-                <TouchableOpacity id="viewSavedFoodItemsButton"
-                    style={[styles.bodyButtonAlt, {backgroundColor: usernameGlobal == '' ? '#FFFFFF' : '#FFFFFF'}]}
-                    onPressIn={() => setIsViewSavedFoodItemsPressed(true)}
-                    onPressOut={() => setIsViewSavedFoodItemsPressed(false)}
-                    onPress={() => router.push("/entries")}
-                    disabled={usernameGlobal == '' ? true : false}>
+                            <Text id="viewSavedFoodItemsButtonText"
+                                style={[styles.bodyButtonTextDefault, {backgroundColor: usernameGlobal === '' ? '#666666' : '#131312'}]}>
+                                View Saved Foods
+                            </Text>
+                        </TouchableOpacity>
 
-                    <Text id="viewSavedFoodItemsButtonText" style={[styles.bodyButtonTextAlt, {color: usernameGlobal == '' ? '#FFFFFF' : '#C5151A'}]}>
-                        View Saved Foods
-                    </Text>
-                </TouchableOpacity>
+                        {/* Route the user to the 'statistics' page */}
+                        <TouchableOpacity id="statisticsButton"
+                            style={[styles.bodyButtonDefault,  {backgroundColor: isStatisticsPressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsStatisticsPressed(true)}
+                            onPressOut={() => setIsStatisticsPressed(false)}
+                            onPress={() => router.push("/statistics")}
+                            disabled={usernameGlobal === '' ? true : false}>
+                                
+                            <Text id="statisticsButtonText"
+                                style={[styles.bodyButtonTextDefault, {backgroundColor: usernameGlobal === '' ? '#666666' : '#131312'}]}>
+                                View Statistics
+                            </Text>
+                        </TouchableOpacity>
 
-                {/* Route the user to the 'statistics' page */}
-                <TouchableOpacity id="statisticsButton"
-                    style={[styles.bodyButtonAlt, {backgroundColor: usernameGlobal == '' ? '#FFFFFF' : '#FFFFFF'}]}
-                    onPressIn={() => setIsStatisticsPressed(true)}
-                    onPressOut={() => setIsStatisticsPressed(false)}
-                    onPress={() => router.push("/statistics")}
-                    disabled={usernameGlobal == '' ? true : false}>
-                        
-                    <Text id="statisticsButtonText" style={[styles.bodyButtonTextAlt, {color: usernameGlobal == '' ? '#FFFFFF' : '#C5151A'}]}>
-                        View Stats
-                    </Text>
-                </TouchableOpacity>
+                        {/* Route the user to the 'recommendations' page */}
+                        <TouchableOpacity id="recommendationsButton"
+                            style={[styles.bodyButtonDefault,  {backgroundColor: isRecommendationsPressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsRecommendationsPressed(true)}
+                            onPressOut={() => setIsRecommendationsPressed(false)}
+                            onPress={() => router.push("/recommendations")}
+                            disabled={usernameGlobal === '' ? true : false}>
 
-                {/* Route the user to the 'recommendations' page */}
-                <TouchableOpacity id="recommendationsButton"
-                    style={[styles.bodyButtonAlt, {backgroundColor: usernameGlobal == '' ? '#FFFFFF' : '#FFFFFF'}]}
-                    onPressIn={() => setIsRecommendationsPressed(true)}
-                    onPressOut={() => setIsRecommendationsPressed(false)}
-                    onPress={() => router.push("/recommendations")}
-                    disabled={usernameGlobal == '' ? true : false}>
+                            <Text id="recommendationsButtonText"
+                                style={[styles.bodyButtonTextDefault, {backgroundColor: usernameGlobal === '' ? '#666666' : '#131312'}]}>
+                                View Food and Dining Recommendations
+                            </Text>
+                        </TouchableOpacity>
+                    </View>
+                )}
 
-                    <Text id="recommendationsButtonText" style={[styles.bodyButtonTextAlt, {color: usernameGlobal == '' ? '#FFFFFF' : '#C5151A'}]}>
-                        View Recs
-                    </Text>
-                </TouchableOpacity>
+                {/* Display buttons that are related to browsing food items or browsing dining locations */}
+                {browseButtons && (
+                    <View id="browseButtonsView" style={styles.container}>
+
+                        {/* Route the user to the 'browse food items' page */}
+                        <TouchableOpacity id="browseFoodItemsButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isBrowseFoodItemsPressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsBrowseFoodItemsPressed(true)}
+                            onPressOut={() => setIsBrowseFoodItemsPressed(false)}
+                            onPress={() => router.push("/enter")}
+                            disabled={usernameGlobal === '' ? true : false}>
+
+                            <Text id="browseFoodItemsButtonText" style={styles.bodyButtonTextDefault}>
+                                Browse Food
+                            </Text>
+                        </TouchableOpacity>
+
+                        {/* Route the user to the 'browse dining locations' page */}
+                        <TouchableOpacity id="browseDiningLocationsButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isBrowseDiningLocationsPressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsBrowseDiningLocationsPressed(true)}
+                            onPressOut={() => setIsBrowseDiningLocationsPressed(false)}
+                            onPress={() => router.push("/dining")}
+                            disabled={usernameGlobal === '' ? true : false}>
+
+                            <Text id="browseDiningLocationsButtonText" style={styles.bodyButtonTextDefault}>
+                                Browse Dining
+                            </Text>
+                        </TouchableOpacity>
+
+                        {/* Route the user to the 'browse dining locations' page */}
+                        <TouchableOpacity id="browseDiningLocationsButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isBrowseDiningLocationsPressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsBrowseDiningLocationsPressed(true)}
+                            onPressOut={() => setIsBrowseDiningLocationsPressed(false)}
+                            onPress={() => setBrowseButtons(false)}
+                            disabled={usernameGlobal === '' ? true : false}>
+
+                            <Text id="browseDiningLocationsButtonText" style={styles.bodyButtonTextDefault}>
+                                Back
+                            </Text>
+                        </TouchableOpacity>
+
+                    </View>
+                )}
 
             </ScrollView>
 

--- a/frontend/cu-bytes/app/home.tsx
+++ b/frontend/cu-bytes/app/home.tsx
@@ -194,7 +194,7 @@ export default function HomeScreen() {
                             </Text>
                         </TouchableOpacity>
 
-                        {/* Route the user to the 'browse food items' page */}
+                        {/* Button that allows the browse food items and browse dining locations buttons to be displayed */}
                         <TouchableOpacity id="browseButton"
                             style={[styles.bodyButtonDefault, {backgroundColor: isBrowsePressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
                             onPressIn={() => setIsBrowseFoodItemsPressed(true)}
@@ -277,11 +277,11 @@ export default function HomeScreen() {
                             disabled={usernameGlobal === '' ? true : false}>
 
                             <Text id="browseDiningLocationsButtonText" style={styles.bodyButtonTextDefault}>
-                                Browse Dining
+                                Browse Dining Locations
                             </Text>
                         </TouchableOpacity>
 
-                        {/* Route the user to the 'browse dining locations' page */}
+                        {/* Display the buttons that were previously displayed */}
                         <TouchableOpacity id="browseDiningLocationsButton"
                             style={[styles.bodyButtonDefault, {backgroundColor: isBrowseDiningLocationsPressed || usernameGlobal === '' ? '#666666' : '#131312'}]}
                             onPressIn={() => setIsBrowseDiningLocationsPressed(true)}

--- a/frontend/cu-bytes/app/home.tsx
+++ b/frontend/cu-bytes/app/home.tsx
@@ -12,14 +12,16 @@ export default function HomeScreen() {
 
     const [loading, setLoading] = useState(false);
     const [modalVisible, setModalVisible] = useState(false);
+    
+    const [isSettingsPressed, setIsSettingsPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
+
     const [isScanFoodItemPressed, setIsScanFoodItemPressed] = useState(false);
     const [isBrowseFoodItemsPressed, setIsBrowseFoodItemsPressed] = useState(false);
     const [isBrowseDiningLocationsPressed, setIsBrowseDiningLocationsPressed] = useState(false);
     const [isViewSavedFoodItemsPressed, setIsViewSavedFoodItemsPressed] = useState(false);
     const [isStatisticsPressed, setIsStatisticsPressed] = useState(false);
     const [isRecommendationsPressed, setIsRecommendationsPressed] = useState(false)
-    const [isSettingsPressed, setIsSettingsPressed] = useState(false);
 
     /*
         Variables used to store a copy of the logged-in user's username and profile settings
@@ -107,6 +109,18 @@ export default function HomeScreen() {
             <StatusBar style="auto" hidden={true}/>
 
             <View id="homeStatusbar" style={styles.statusbar}>
+
+                {/* Route the user to the 'settings' page */}
+                <TouchableOpacity id="settingsButton"
+                    style={[styles.headerButtonDefault, {backgroundColor: isSettingsPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsSettingsPressed(true)}
+                    onPressOut={() => setIsSettingsPressed(false)}
+                    onPress={() => router.push("/settings")}>
+                    
+                    <Text id="settingsButtonText" style={styles.headerButtonTextDefault}>
+                        Settings
+                    </Text>
+                </TouchableOpacity>
 
                 <Text id="loggedInUser" style={styles.headerUsernameIcon}>
                     {usernameGlobal != '' ? `${usernameGlobal}` : 'Guest'}
@@ -234,19 +248,6 @@ export default function HomeScreen() {
 
                     <Text id="recommendationsButtonText" style={[styles.bodyButtonTextAlt, {color: usernameGlobal == '' ? '#FFFFFF' : '#C5151A'}]}>
                         View Recs
-                    </Text>
-                </TouchableOpacity>
-
-                {/* Route the user to the 'settings' page */}
-                <TouchableOpacity id="settingsButton"
-                    style={[styles.bodyButtonAlt, {backgroundColor: usernameGlobal == '' ? '#FFFFFF' : '#FFFFFF'}]}
-                    onPressIn={() => setIsSettingsPressed(true)}
-                    onPressOut={() => setIsSettingsPressed(false)}
-                    onPress={() => router.push("/settings")}
-                    disabled={usernameGlobal == '' ? true : false}>
-                    
-                    <Text id="settingsButtonText" style={[styles.bodyButtonTextAlt, {color: usernameGlobal == '' ? '#FFFFFF' : '#C5151A'}]}>
-                        Settings
                     </Text>
                 </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/index.tsx
+++ b/frontend/cu-bytes/app/index.tsx
@@ -37,7 +37,7 @@ export default function IndexScreen() {
 
                 {/* Route the user to the 'login' page */}
                 <TouchableOpacity id="loginButton"
-                    style={[styles.bodyButtonDefault, {backgroundColor: isLoginPressed ? '#6666666' : '#131312'}]}
+                    style={[styles.bodyButtonDefault, {backgroundColor: isLoginPressed ? '#666666' : '#131312'}]}
                     onPressIn={() => setIsLoginPressed(true)}
                     onPressOut={() => setIsLoginPressed(false)}
                     onPress={() => router.push("/login")}>
@@ -49,36 +49,36 @@ export default function IndexScreen() {
 
                 {/* Route the user to the 'scan food item' page */}
                 <TouchableOpacity id="scanFoodButton"
-                    style={[styles.bodyButtonAlt, {backgroundColor: isScanFoodItemPressed ? '#DDDDDD' : '#FFFFFF'}]}
+                    style={[styles.bodyButtonDefault, {backgroundColor: isScanFoodItemPressed ? '#666666' : '#131312'}]}
                     onPressIn={() => setIsScanFoodItemPressed(true)}
                     onPressOut={() => setIsScanFoodItemPressed(false)}
                     onPress={() => router.push("/scan")}>
 
-                    <Text id="scanFoodButtonText" style={styles.bodyButtonTextAlt}>
+                    <Text id="scanFoodButtonText" style={styles.bodyButtonTextDefault}>
                         Scan Food
                     </Text>
                 </TouchableOpacity>
             
                 {/* Route the user to the 'browse food items' page */}
                 <TouchableOpacity id="browseFoodButton"
-                    style={[styles.bodyButtonAlt, {backgroundColor: isBrowseFoodItemsPressed ? '#DDDDDD' : '#FFFFFF'}]}
+                    style={[styles.bodyButtonDefault, {backgroundColor: isBrowseFoodItemsPressed ? '#666666' : '#131312'}]}
                     onPressIn={() => setIsBrowseFoodItemsPressed(true)}
                     onPressOut={() => setIsBrowseFoodItemsPressed(false)}
                     onPress={() => router.push("/enter")}>
 
-                    <Text id="browseFoodButtonText" style={styles.bodyButtonTextAlt}>
+                    <Text id="browseFoodButtonText" style={styles.bodyButtonTextDefault}>
                         Browse Food
                     </Text>
                 </TouchableOpacity>
 
                 {/* Route the user to the 'browse dining locations' page */}
                 <TouchableOpacity id="browseDiningButton"
-                    style={[styles.bodyButtonAlt, {backgroundColor: isBrowseDiningLocationsPressed ? '#DDDDDD' : '#FFFFFF'}]}
+                    style={[styles.bodyButtonDefault, {backgroundColor: isBrowseDiningLocationsPressed ? '#666666' : '#131312'}]}
                     onPressIn={() => setIsBrowseDiningLocationsPressed(true)}
                     onPressOut={() => setIsBrowseDiningLocationsPressed(false)}
                     onPress={() => router.push("/dining")}>
 
-                    <Text id="browseDiningButtonText" style={styles.bodyButtonTextAlt}>
+                    <Text id="browseDiningButtonText" style={styles.bodyButtonTextDefault}>
                         Browse Dining
                     </Text>
                 </TouchableOpacity>

--- a/frontend/cu-bytes/app/index.tsx
+++ b/frontend/cu-bytes/app/index.tsx
@@ -9,8 +9,10 @@ import { styles } from './_styles/style-index';
 export default function IndexScreen() {
 
     const [loading, setLoading] = useState(false);
+    const [browseButtons, setBrowseButtons] = useState(false);
     const [isLoginPressed, setIsLoginPressed] = useState(false);
     const [isScanFoodItemPressed, setIsScanFoodItemPressed] = useState(false);
+    const [isBrowsePressed, setIsBrowsePressed] = useState(false);
     const [isBrowseFoodItemsPressed, setIsBrowseFoodItemsPressed] = useState(false);
     const [isBrowseDiningLocationsPressed, setIsBrowseDiningLocationsPressed] = useState(false);
     
@@ -35,53 +37,90 @@ export default function IndexScreen() {
                     Track Your Campus Meals!
                 </Text>
 
-                {/* Route the user to the 'login' page */}
-                <TouchableOpacity id="loginButton"
-                    style={[styles.bodyButtonDefault, {backgroundColor: isLoginPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsLoginPressed(true)}
-                    onPressOut={() => setIsLoginPressed(false)}
-                    onPress={() => router.push("/login")}>
+                {/* Display buttons that are not related to browsing food items or browsing dining locations */}
+                {!browseButtons && (
+                    <View id="defaultButtonsView" style={styles.container}>
 
-                    <Text id="loginButtonText" style={styles.bodyButtonTextDefault}>
-                        Login
-                    </Text>
-                </TouchableOpacity>
+                        {/* Route the user to the 'login' page */}
+                        <TouchableOpacity id="loginButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isLoginPressed ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsLoginPressed(true)}
+                            onPressOut={() => setIsLoginPressed(false)}
+                            onPress={() => router.push("/login")}>
 
-                {/* Route the user to the 'scan food item' page */}
-                <TouchableOpacity id="scanFoodButton"
-                    style={[styles.bodyButtonDefault, {backgroundColor: isScanFoodItemPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsScanFoodItemPressed(true)}
-                    onPressOut={() => setIsScanFoodItemPressed(false)}
-                    onPress={() => router.push("/scan")}>
+                            <Text id="loginButtonText" style={styles.bodyButtonTextDefault}>
+                                Login
+                            </Text>
+                        </TouchableOpacity>
 
-                    <Text id="scanFoodButtonText" style={styles.bodyButtonTextDefault}>
-                        Scan Food
-                    </Text>
-                </TouchableOpacity>
-            
-                {/* Route the user to the 'browse food items' page */}
-                <TouchableOpacity id="browseFoodButton"
-                    style={[styles.bodyButtonDefault, {backgroundColor: isBrowseFoodItemsPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBrowseFoodItemsPressed(true)}
-                    onPressOut={() => setIsBrowseFoodItemsPressed(false)}
-                    onPress={() => router.push("/enter")}>
+                        {/* Route the user to the 'scan food item' page */}
+                        <TouchableOpacity id="scanFoodButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isScanFoodItemPressed ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsScanFoodItemPressed(true)}
+                            onPressOut={() => setIsScanFoodItemPressed(false)}
+                            onPress={() => router.push("/scan")}>
 
-                    <Text id="browseFoodButtonText" style={styles.bodyButtonTextDefault}>
-                        Browse Food
-                    </Text>
-                </TouchableOpacity>
+                            <Text id="scanFoodButtonText" style={styles.bodyButtonTextDefault}>
+                                Scan Food
+                            </Text>
+                        </TouchableOpacity>
 
-                {/* Route the user to the 'browse dining locations' page */}
-                <TouchableOpacity id="browseDiningButton"
-                    style={[styles.bodyButtonDefault, {backgroundColor: isBrowseDiningLocationsPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBrowseDiningLocationsPressed(true)}
-                    onPressOut={() => setIsBrowseDiningLocationsPressed(false)}
-                    onPress={() => router.push("/dining")}>
+                        {/* Button that allows the browse food items and browse dining locations buttons to be displayed */}
+                        <TouchableOpacity id="browseButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isBrowsePressed ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsBrowseFoodItemsPressed(true)}
+                            onPressOut={() => setIsBrowseFoodItemsPressed(false)}
+                            onPress={() => setBrowseButtons(true)}>
 
-                    <Text id="browseDiningButtonText" style={styles.bodyButtonTextDefault}>
-                        Browse Dining
-                    </Text>
-                </TouchableOpacity>
+                            <Text id="browseButtonText" style={styles.bodyButtonTextDefault}>
+                                Browse
+                            </Text>
+                        </TouchableOpacity>
+                    </View>
+                )}
+
+                {/* Display buttons that are related to browsing food items or browsing dining locations */}
+                {browseButtons && (
+                    <View id="browseButtonsView" style={styles.container}>
+
+                        {/* Route the user to the 'browse food items' page */}
+                        <TouchableOpacity id="browseFoodButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isBrowseFoodItemsPressed ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsBrowseFoodItemsPressed(true)}
+                            onPressOut={() => setIsBrowseFoodItemsPressed(false)}
+                            onPress={() => router.push("/enter")}>
+
+                            <Text id="browseFoodButtonText" style={styles.bodyButtonTextDefault}>
+                                Browse Food
+                            </Text>
+                        </TouchableOpacity>
+
+                        {/* Route the user to the 'browse dining locations' page */}
+                        <TouchableOpacity id="browseDiningButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isBrowseDiningLocationsPressed ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsBrowseDiningLocationsPressed(true)}
+                            onPressOut={() => setIsBrowseDiningLocationsPressed(false)}
+                            onPress={() => router.push("/dining")}>
+
+                            <Text id="browseDiningButtonText" style={styles.bodyButtonTextDefault}>
+                                Browse Dining Locations
+                            </Text>
+                        </TouchableOpacity>
+        
+                        {/* Display the buttons that were previously displayed */}
+                        <TouchableOpacity id="browseDiningLocationsButton"
+                            style={[styles.bodyButtonDefault, {backgroundColor: isBrowseDiningLocationsPressed ? '#666666' : '#131312'}]}
+                            onPressIn={() => setIsBrowseDiningLocationsPressed(true)}
+                            onPressOut={() => setIsBrowseDiningLocationsPressed(false)}
+                            onPress={() => setBrowseButtons(false)}>
+
+                            <Text id="browseDiningLocationsButtonText" style={styles.bodyButtonTextDefault}>
+                                Back
+                            </Text>
+                        </TouchableOpacity>
+
+                    </View>
+                )}
 
             </ScrollView>
 

--- a/frontend/cu-bytes/app/login.tsx
+++ b/frontend/cu-bytes/app/login.tsx
@@ -13,6 +13,7 @@ export default function LoginScreen() {
     const [loading, setLoading] = useState(false);
     const [visible, setVisible] = useState(false);
     const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
     const [isLoginPressed, setIsLoginPressed] = useState(false);
     const [isCreateAccountPressed, setIsCreateAccountPressed] = useState(false);
@@ -166,14 +167,14 @@ export default function LoginScreen() {
             <View id="loginStatusbar" style={styles.statusbar}>
 
                 {/* Route the user to the 'splash' page */}
-                <TouchableOpacity id="backButton"
-                    style={[styles.headerButtonDefault, {backgroundColor: isBackPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBackPressed(true)}
-                    onPressOut={() => setIsBackPressed(false)}
+                <TouchableOpacity id="homeOrSplashButton"
+                    style={[styles.headerButtonDefault, {backgroundColor: isHomeOrSplashPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsHomeOrSplashPressed(true)}
+                    onPressOut={() => setIsHomeOrSplashPressed(false)}
                     onPress={() => router.push('/')}>
 
-                    <Text id="backButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
-                        Back
+                    <Text id="homeOrSplashButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
+                        Home
                     </Text>
                 </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/login.tsx
+++ b/frontend/cu-bytes/app/login.tsx
@@ -12,7 +12,6 @@ export default function LoginScreen() {
 
     const [loading, setLoading] = useState(false);
     const [visible, setVisible] = useState(false);
-    const [isBackPressed, setIsBackPressed] = useState(false);
     const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
     const [isLoginPressed, setIsLoginPressed] = useState(false);
@@ -36,17 +35,19 @@ export default function LoginScreen() {
         {
             usernameGlobal,
             setUsernameGlobal,
+            setHasConfiguredSettingsGlobal,
             setShowStatsGlobal,
+            setHasDairyIntoleranceGlobal,            
             setHasEggAllergyGlobal,
             setHasFishOrShellfishAllergyGlobal,
-            setHasDairyIntoleranceGlobal,
+            setHasGlutenAllergyGlobal,
             setHasMilkAllergyGlobal,
             setHasPeanutAllergyGlobal,
             setHasSesameAllergyGlobal,
+            setHasSulfitesAllergyGlobal,
             setHasSoyAllergyGlobal,
             setHasTreenutAllergyGlobal,
             setHasWheatAllergyGlobal,
-            setHasGlutenAllergyGlobal,
             setIsVeganGlobal,
             setIsVegetarianGlobal,
             setPrefersHalalGlobal
@@ -73,7 +74,8 @@ export default function LoginScreen() {
             const data = await res.json();
 
             // Update the copy of the logged-in user's username and profile settings using the retrieved data
-            setUsernameGlobal(username)
+            setUsernameGlobal(username);
+            setHasConfiguredSettingsGlobal(data.has_configured_settings)
             setShowStatsGlobal(data.show_stats);
             setHasEggAllergyGlobal(data.has_egg_allergy);
             setHasFishOrShellfishAllergyGlobal(data.has_fish_or_shellfish_allergy);
@@ -82,6 +84,7 @@ export default function LoginScreen() {
             setHasPeanutAllergyGlobal(data.has_peanut_allergy);
             setHasSesameAllergyGlobal(data.has_sesame_allergy);
             setHasSoyAllergyGlobal(data.has_soy_allergy);
+            setHasSulfitesAllergyGlobal(data.has_sulfites);
             setHasTreenutAllergyGlobal(data.has_treenut_allergy);
             setHasWheatAllergyGlobal(data.has_wheat_allergy);
             setHasGlutenAllergyGlobal(data.has_gluten_allergy);
@@ -135,22 +138,24 @@ export default function LoginScreen() {
     }
 
     /*
-        Log out the logged-in user by setting their username and profile settings to null, and routing to the splash page
+        Log out the logged-in user by setting their profile settings to false, and routing to the splash page
     */
     const logout = () => { 
         
         setUsernameGlobal('');
+        setHasConfiguredSettingsGlobal(false);
         setShowStatsGlobal(false);
+        setHasDairyIntoleranceGlobal(false);        
         setHasEggAllergyGlobal(false);
         setHasFishOrShellfishAllergyGlobal(false);
-        setHasDairyIntoleranceGlobal(false);
+        setHasGlutenAllergyGlobal(false);
         setHasMilkAllergyGlobal(false);
         setHasPeanutAllergyGlobal(false);
         setHasSesameAllergyGlobal(false);
         setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergyGlobal(false);
         setHasTreenutAllergyGlobal(false);
         setHasWheatAllergyGlobal(false);
-        setHasGlutenAllergyGlobal(false);
         setIsVeganGlobal(false);
         setIsVegetarianGlobal(false);
         setPrefersHalalGlobal(false);

--- a/frontend/cu-bytes/app/recommendations.tsx
+++ b/frontend/cu-bytes/app/recommendations.tsx
@@ -53,17 +53,17 @@ export default function RecommendationsScreen() {
     const {
         usernameGlobal,
         setUsernameGlobal,
-        setShowStatsGlobal,
+        setHasDairyIntoleranceGlobal,            
         setHasEggAllergyGlobal,
         setHasFishOrShellfishAllergyGlobal,
-        setHasDairyIntoleranceGlobal,
+        setHasGlutenAllergyGlobal,
         setHasMilkAllergyGlobal,
         setHasPeanutAllergyGlobal,
         setHasSesameAllergyGlobal,
+        setHasSulfitesAllergyGlobal,
         setHasSoyAllergyGlobal,
         setHasTreenutAllergyGlobal,
         setHasWheatAllergyGlobal,
-        setHasGlutenAllergyGlobal,
         setIsVeganGlobal,
         setIsVegetarianGlobal,
         setPrefersHalalGlobal
@@ -307,22 +307,22 @@ export default function RecommendationsScreen() {
     }
 
     /*
-        Log out the logged-in user by setting their username and profile settings to null 
+        Log out the logged-in user by setting their profile settings to false, and routing to the splash page
     */
-    const logout = () => {
-
+    const logout = () => { 
+        
         setUsernameGlobal('');
-        setShowStatsGlobal(false);
+        setHasDairyIntoleranceGlobal(false);        
         setHasEggAllergyGlobal(false);
         setHasFishOrShellfishAllergyGlobal(false);
-        setHasDairyIntoleranceGlobal(false);
+        setHasGlutenAllergyGlobal(false);
         setHasMilkAllergyGlobal(false);
         setHasPeanutAllergyGlobal(false);
         setHasSesameAllergyGlobal(false);
         setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergyGlobal(false);
         setHasTreenutAllergyGlobal(false);
         setHasWheatAllergyGlobal(false);
-        setHasGlutenAllergyGlobal(false);
         setIsVeganGlobal(false);
         setIsVegetarianGlobal(false);
         setPrefersHalalGlobal(false);

--- a/frontend/cu-bytes/app/recommendations.tsx
+++ b/frontend/cu-bytes/app/recommendations.tsx
@@ -35,7 +35,7 @@ export default function RecommendationsScreen() {
     */
     const [fetchedRecommendations, setFetchedRecommendations] = useState(false);
 
-    const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
     const [isTrendingPressed, setIsTrendingPressed] = useState(false);
     const [isRandomPressed, setIsRandomPressed] = useState(false);
@@ -461,14 +461,14 @@ export default function RecommendationsScreen() {
             <View id="viewRecommendationsStatusbar" style={styles.statusbar}>
 
                 {/* Route the user to the 'home' page or the 'splash' page */}
-                <TouchableOpacity id="backButton"
-                    style={[styles.headerButtonDefault, {backgroundColor: isBackPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBackPressed(true)}
-                    onPressOut={() => setIsBackPressed(false)}
+                <TouchableOpacity id="homeOrSplashButton"
+                    style={[styles.headerButtonDefault, {backgroundColor: isHomeOrSplashPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsHomeOrSplashPressed(true)}
+                    onPressOut={() => setIsHomeOrSplashPressed(false)}
                     onPress={() => usernameGlobal != '' ? router.push('/home') : router.push('/')}>
 
-                    <Text id="backButtonText" style={styles.headerButtonTextDefault}>
-                        Back
+                    <Text id="homeOrSplashButtonText" style={styles.headerButtonTextDefault}>
+                        Home
                     </Text>
                 </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/register.tsx
+++ b/frontend/cu-bytes/app/register.tsx
@@ -34,17 +34,19 @@ export default function RegisterScreen() {
         {
             usernameGlobal,
             setUsernameGlobal,
+            setHasConfiguredSettingsGlobal,
             setShowStatsGlobal,
+            setHasDairyIntoleranceGlobal,            
             setHasEggAllergyGlobal,
             setHasFishOrShellfishAllergyGlobal,
-            setHasDairyIntoleranceGlobal,
+            setHasGlutenAllergyGlobal,
             setHasMilkAllergyGlobal,
             setHasPeanutAllergyGlobal,
             setHasSesameAllergyGlobal,
+            setHasSulfitesAllergyGlobal,
             setHasSoyAllergyGlobal,
             setHasTreenutAllergyGlobal,
             setHasWheatAllergyGlobal,
-            setHasGlutenAllergyGlobal,
             setIsVeganGlobal,
             setIsVegetarianGlobal,
             setPrefersHalalGlobal
@@ -71,6 +73,7 @@ export default function RegisterScreen() {
 
             // Update the copy of the logged-in user's username and profile settings using the retrieved data
             setUsernameGlobal(username);
+            setHasConfiguredSettingsGlobal(data.has_configured_settings)
             setShowStatsGlobal(data.show_stats);
             setHasEggAllergyGlobal(data.has_egg_allergy);
             setHasFishOrShellfishAllergyGlobal(data.has_fish_or_shellfish_allergy);
@@ -79,6 +82,7 @@ export default function RegisterScreen() {
             setHasPeanutAllergyGlobal(data.has_peanut_allergy);
             setHasSesameAllergyGlobal(data.has_sesame_allergy);
             setHasSoyAllergyGlobal(data.has_soy_allergy);
+            setHasSulfitesAllergyGlobal(data.has_sulfites);
             setHasTreenutAllergyGlobal(data.has_treenut_allergy);
             setHasWheatAllergyGlobal(data.has_wheat_allergy);
             setHasGlutenAllergyGlobal(data.has_gluten_allergy);
@@ -136,11 +140,28 @@ export default function RegisterScreen() {
     }
 
     /*
-        Log out the logged-in user by setting their username and profile settings to null, and routing to the splash page
+        Log out the logged-in user by setting their profile settings to false, and routing to the splash page
     */
     const logout = () => { 
         
         setUsernameGlobal('');
+        setHasConfiguredSettingsGlobal(false);
+        setShowStatsGlobal(false);
+        setHasDairyIntoleranceGlobal(false);        
+        setHasEggAllergyGlobal(false);
+        setHasFishOrShellfishAllergyGlobal(false);
+        setHasGlutenAllergyGlobal(false);
+        setHasMilkAllergyGlobal(false);
+        setHasPeanutAllergyGlobal(false);
+        setHasSesameAllergyGlobal(false);
+        setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergyGlobal(false);
+        setHasTreenutAllergyGlobal(false);
+        setHasWheatAllergyGlobal(false);
+        setIsVeganGlobal(false);
+        setIsVegetarianGlobal(false);
+        setPrefersHalalGlobal(false);
+
         router.push('/');
     }
 

--- a/frontend/cu-bytes/app/register.tsx
+++ b/frontend/cu-bytes/app/register.tsx
@@ -12,7 +12,7 @@ export default function RegisterScreen() {
 
     const [loading, setLoading] = useState(false);
     const [visible, setVisible] = useState(false);
-    const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
     const [isCreateAccountPressed, setIsCreateAccountPressed] = useState(false);
     const [secureTextEntry, setSecureTextEntry] = useState(true);
@@ -153,14 +153,14 @@ export default function RegisterScreen() {
             <View id="registerStatusbar" style={styles.statusbar}>
 
                 {/* Route the user to the 'splash' page */}
-                <TouchableOpacity id="backButton"
-                    style={[styles.headerButtonDefault, {backgroundColor: isBackPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBackPressed(true)}
-                    onPressOut={() => setIsBackPressed(false)}
+                <TouchableOpacity id="homeOrSplashButton"
+                    style={[styles.headerButtonDefault, {backgroundColor: isHomeOrSplashPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsHomeOrSplashPressed(true)}
+                    onPressOut={() => setIsHomeOrSplashPressed(false)}
                     onPress={() => router.push('/login')}>
 
-                    <Text id="backButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
-                        Back
+                    <Text id="homeOrSplashButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
+                        Home
                     </Text>
                 </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/scan.tsx
+++ b/frontend/cu-bytes/app/scan.tsx
@@ -359,6 +359,31 @@ export default function ScanScreen() {
     }
 
     /*
+        If the user is not logged-in, set the profile settings to true,
+        So that all allergy and intolerance warnings will be displayed by default
+    */
+    useEffect(() => {
+        
+        if (usernameGlobal === '') {
+            setHasDairyIntoleranceGlobal(true);
+            setHasEggAllergyGlobal(true);
+            setHasFishOrShellfishAllergyGlobal(true);
+            setHasGlutenAllergyGlobal(true);
+            setHasMilkAllergyGlobal(true);
+            setHasPeanutAllergyGlobal(true);
+            setHasSesameAllergyGlobal(true);
+            setHasSulfitesAllergyGlobal(true);
+            setHasSoyAllergyGlobal(true);
+            setHasTreenutAllergyGlobal(true);
+            setHasWheatAllergyGlobal(true);
+            setIsVeganGlobal(true);
+            setIsVegetarianGlobal(true);
+            setPrefersHalalGlobal(true);
+        }
+
+    }, []);
+
+    /*
         Enable the user to select an image on the device that the CU-Bytes application is running on
         The selected image will be analyzed by the machine learning component
     */
@@ -813,18 +838,20 @@ export default function ScanScreen() {
                             </Text>
                         </TouchableOpacity>
 
-                        <TouchableOpacity id="saveFoodItemButton" style={[styles.bodyButtonAlt]}
-                            onPress={() => {
-                                logFoodItemByName(prediction.food_name);
-                                setSavedFoodItemMessage(true);
-                                setTimeout(() => {setSavedFoodItemMessage(false);}, 2000);
-                                router.push('/home');}}
-                            disabled={loading}>
+                        {usernameGlobal !== '' && (
+                            <TouchableOpacity id="saveFoodItemButton" style={[styles.bodyButtonAlt]}
+                                onPress={() => {
+                                    logFoodItemByName(prediction.food_name);
+                                    setSavedFoodItemMessage(true);
+                                    setTimeout(() => {setSavedFoodItemMessage(false);}, 2000);
+                                    router.push('/home');}}
+                                disabled={loading}>
 
-                            <Text id="saveFoodItemButtonText" style={styles.bodyButtonTextAlt}>
-                                Save Food Item
-                            </Text>
-                        </TouchableOpacity>
+                                <Text id="saveFoodItemButtonText" style={styles.bodyButtonTextAlt}>
+                                    Save Food Item
+                                </Text>
+                            </TouchableOpacity>
+                        )}
 
                     </View>
                 )}
@@ -904,19 +931,21 @@ export default function ScanScreen() {
                                 Scan Other
                             </Text>
                         </TouchableOpacity>
+                        
+                        {usernameGlobal !== '' && (
+                            <TouchableOpacity id="saveFoodItemButton" style={[styles.bodyButtonAlt]}
+                                onPress={() => {
+                                    logFoodItemById(foodItem.id);
+                                    setSavedFoodItemMessage(true);
+                                    setTimeout(() => {setSavedFoodItemMessage(false);}, 2000);
+                                    router.push('/home');}}
+                                disabled={loading}>
 
-                        <TouchableOpacity id="saveFoodItemButton" style={[styles.bodyButtonAlt]}
-                            onPress={() => {
-                                logFoodItemById(foodItem.id);
-                                setSavedFoodItemMessage(true);
-                                setTimeout(() => {setSavedFoodItemMessage(false);}, 2000);
-                                router.push('/home');}}
-                            disabled={loading}>
-
-                            <Text id="saveFoodItemButtonText" style={styles.bodyButtonTextAlt}>
-                                Save Food Item
-                            </Text>
-                        </TouchableOpacity>
+                                <Text id="saveFoodItemButtonText" style={styles.bodyButtonTextAlt}>
+                                    Save Food Item
+                                </Text>
+                            </TouchableOpacity>
+                        )}
 
                     </View>
                 )}

--- a/frontend/cu-bytes/app/scan.tsx
+++ b/frontend/cu-bytes/app/scan.tsx
@@ -74,13 +74,14 @@ export default function ScanScreen() {
     const
         {
             usernameGlobal,
-            hasDairyIntoleranceGlobal,
+            hasDairyIntoleranceGlobal,            
             hasEggAllergyGlobal,
             hasFishOrShellfishAllergyGlobal,
             hasGlutenAllergyGlobal,            
             hasMilkAllergyGlobal,
             hasPeanutAllergyGlobal,
             hasSesameAllergyGlobal,
+            hasSulfitesAllergyGlobal,
             hasSoyAllergyGlobal,
             hasTreenutAllergyGlobal,
             hasWheatAllergyGlobal,
@@ -88,21 +89,20 @@ export default function ScanScreen() {
             isVegetarianGlobal,
             prefersHalalGlobal,
             setUsernameGlobal,
-            setHasConfiguredSettingsGlobal,
-            setShowStatsGlobal,
-            setHasDairyIntoleranceGlobal,
+            setHasDairyIntoleranceGlobal,            
             setHasEggAllergyGlobal,
             setHasFishOrShellfishAllergyGlobal,
             setHasGlutenAllergyGlobal,
             setHasMilkAllergyGlobal,
             setHasPeanutAllergyGlobal,
             setHasSesameAllergyGlobal,
+            setHasSulfitesAllergyGlobal,
             setHasSoyAllergyGlobal,
             setHasTreenutAllergyGlobal,
             setHasWheatAllergyGlobal,
             setIsVeganGlobal,
             setIsVegetarianGlobal,
-            setPrefersHalalGlobal,
+            setPrefersHalalGlobal
 
         } = useUser();
 
@@ -127,6 +127,7 @@ export default function ScanScreen() {
             has_peanuts: null,
             has_sesame: null,
             has_soy: null,
+            has_sulfites: null,
             has_treenuts: null,
             has_wheat: null,
             id: -1, // Initial value of 1 to prevent errors
@@ -154,6 +155,7 @@ export default function ScanScreen() {
             has_peanuts: null,
             has_sesame: null,
             has_soy: null,
+            has_sulfites: null,
             has_treenuts: null,
             has_wheat: null,
             id: number,
@@ -268,12 +270,6 @@ export default function ScanScreen() {
 
         let foodItemWarningsArray = Array();
 
-        if (foodItem["is_dairy_free"] === false && hasDairyIntoleranceGlobal) {
-            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains dairy" });
-        }
-        if (foodItem["is_dairy_free"] === null && hasDairyIntoleranceGlobal) {
-            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain dairy" });
-        }
         if (foodItem["has_eggs"] === true && hasEggAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains eggs" });
         }
@@ -285,6 +281,12 @@ export default function ScanScreen() {
         }
         if (foodItem["has_fish_or_shellfish"] === null && hasFishOrShellfishAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain fish or shellfish" });
+        }
+        if (foodItem["is_dairy_free"] === false && hasDairyIntoleranceGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains dairy" });
+        }
+        if (foodItem["is_dairy_free"] === null && hasDairyIntoleranceGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain dairy" });
         }
         if (foodItem["has_milk"] === true && hasMilkAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains milk" });
@@ -310,6 +312,12 @@ export default function ScanScreen() {
         if (foodItem["has_soy"] === null && hasSoyAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain soy" });
         }
+        if (foodItem["has_sulfites"] === true && hasSulfitesAllergyGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains sulfites" });
+        }
+        if (foodItem["has_sulfites"] === null && hasSulfitesAllergyGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain sulfites" });
+        }
         if (foodItem["has_treenuts"] === true && hasTreenutAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains treenuts" });
         }
@@ -321,6 +329,12 @@ export default function ScanScreen() {
         }
         if (foodItem["has_wheat"] === null && hasWheatAllergyGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain wheat" });
+        }
+        if (foodItem["is_gluten_free"] === false && hasGlutenAllergyGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item contains gluten" });
+        }
+        if (foodItem["is_gluten_free"] === null && hasGlutenAllergyGlobal) {
+            foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item may contain gluten" });
         }
         if (foodItem["is_vegan"] === false && isVeganGlobal) {
             foodItemWarningsArray.push({ field_name: "Warning", field_value: "This item is not vegan" });
@@ -551,14 +565,12 @@ export default function ScanScreen() {
     }
 
     /*
-        Log out the logged-in user by setting their username and profile settings to their defaults, and routing to the splash page
+        Log out the logged-in user by setting their profile settings to false, and routing to the splash page
     */
     const logout = () => { 
-
+        
         setUsernameGlobal('');
-        setHasConfiguredSettingsGlobal(false);
-        setShowStatsGlobal(false);
-        setHasDairyIntoleranceGlobal(false);
+        setHasDairyIntoleranceGlobal(false);        
         setHasEggAllergyGlobal(false);
         setHasFishOrShellfishAllergyGlobal(false);
         setHasGlutenAllergyGlobal(false);
@@ -566,6 +578,7 @@ export default function ScanScreen() {
         setHasPeanutAllergyGlobal(false);
         setHasSesameAllergyGlobal(false);
         setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergyGlobal(false);
         setHasTreenutAllergyGlobal(false);
         setHasWheatAllergyGlobal(false);
         setIsVeganGlobal(false);

--- a/frontend/cu-bytes/app/scan.tsx
+++ b/frontend/cu-bytes/app/scan.tsx
@@ -61,7 +61,7 @@ export default function ScanScreen() {
     const [selectedImage, setSelectedImage] = useState<string | null>(null);
     const [prediction, setPrediction] = useState<PredictionResult | null>(null);
     const [lowConfidenceMessage, setLowConfidenceMessage] = useState<string | null>(null);
-    const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
 
     const [isBrowseSimilarPressed, setIsBrowseSimilarPressed] = useState(false);
@@ -583,13 +583,13 @@ export default function ScanScreen() {
             <View id="scanFoodItemsStatusbar" style={styles.statusbar}>
 
                 {/* Route the user to the 'home' page or the 'splash' page */}
-                <TouchableOpacity id="backButton" style={[styles.headerButtonDefault, {backgroundColor: isBackPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBackPressed(true)}
-                    onPressOut={() => setIsBackPressed(false)}
+                <TouchableOpacity id="backButton" style={[styles.headerButtonDefault, {backgroundColor: isHomeOrSplashPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsHomeOrSplashPressed(true)}
+                    onPressOut={() => setIsHomeOrSplashPressed(false)}
                     onPress={() => usernameGlobal != '' ? router.push('/home') : router.push('/')}>
 
                     <Text id="backButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
-                        Back
+                        Home
                     </Text>
                 </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/settings.tsx
+++ b/frontend/cu-bytes/app/settings.tsx
@@ -11,7 +11,7 @@ import { API_BASE_URL } from '../services/api';
 export default function SettingsScreen() {
 
     const [loading, setLoading] = useState(true);
-    const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
     const [isConfirmPressed, setIsConfirmPressed] = useState(false);
     const [isChangePasswordPressed, setIsChangePasswordPressed] = useState(false);
@@ -294,14 +294,14 @@ export default function SettingsScreen() {
             <View id="settingsStatusbar" style={styles.statusbar}>
 
                 {/* Route the user to the 'home' page */}
-                <TouchableOpacity id="backButton"
-                    style={[styles.headerButtonDefault, {backgroundColor: isBackPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBackPressed(true)}
-                    onPressOut={() => setIsBackPressed(false)}
+                <TouchableOpacity id="homeOrSplashButton"
+                    style={[styles.headerButtonDefault, {backgroundColor: isHomeOrSplashPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsHomeOrSplashPressed(true)}
+                    onPressOut={() => setIsHomeOrSplashPressed(false)}
                     onPress={() => router.push('/home')}>
 
-                    <Text id="backButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
-                        Back
+                    <Text id="homeOrSplashButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
+                        Home
                     </Text>
                 </TouchableOpacity>
 

--- a/frontend/cu-bytes/app/settings.tsx
+++ b/frontend/cu-bytes/app/settings.tsx
@@ -29,6 +29,7 @@ export default function SettingsScreen() {
     const [hasPeanutAllergy, setHasPeanutAllergy] = useState(false);
     const [hasSesameAllergy, setHasSesameAllergy] = useState(false);
     const [hasSoyAllergy, setHasSoyAllergy] = useState(false);
+    const [hasSulfitesAllergy, setHasSulfitesAllergy] = useState(false);
     const [hasTreenutAllergy, setHasTreenutAllergy] = useState(false);
     const [hasWheatAllergy, setHasWheatAllergy] = useState(false);
     const [hasGlutenAllergy, setHasGlutenAllergy] = useState(false);
@@ -62,6 +63,7 @@ export default function SettingsScreen() {
             setHasPeanutAllergyGlobal,
             setHasSesameAllergyGlobal,
             setHasSoyAllergyGlobal,
+            setHasSulfitesAllergyGlobal,
             setHasTreenutAllergyGlobal,
             setHasWheatAllergyGlobal,
             setHasGlutenAllergyGlobal,
@@ -89,6 +91,7 @@ export default function SettingsScreen() {
                 setHasPeanutAllergyGlobal(data.has_peanut_allergy);
                 setHasSesameAllergyGlobal(data.has_sesame_allergy);
                 setHasSoyAllergyGlobal(data.has_soy_allergy);
+                setHasSulfitesAllergyGlobal(data.has_sulfites);
                 setHasTreenutAllergyGlobal(data.has_treenut_allergy);
                 setHasWheatAllergyGlobal(data.has_wheat_allergy);
                 setHasGlutenAllergyGlobal(data.has_gluten_allergy);
@@ -104,6 +107,7 @@ export default function SettingsScreen() {
                 setHasPeanutAllergy(data.has_peanut_allergy);
                 setHasSesameAllergy(data.has_sesame_allergy);
                 setHasSoyAllergy(data.has_soy_allergy);
+                setHasSulfitesAllergy(data.has_sulfites);
                 setHasTreenutAllergy(data.has_treenut_allergy);
                 setHasWheatAllergy(data.has_wheat_allergy);
                 setHasGlutenAllergy(data.has_gluten_allergy);
@@ -140,6 +144,7 @@ export default function SettingsScreen() {
                             has_peanut_allergy: hasPeanutAllergy,
                             has_sesame_allergy: hasSesameAllergy,
                             has_soy_allergy: hasSoyAllergy,
+                            has_sulfites_allergy: hasSulfitesAllergy,
                             has_treenut_allergy: hasTreenutAllergy,
                             has_wheat_allergy: hasWheatAllergy,
                             has_gluten_allergy: hasGlutenAllergy,
@@ -160,6 +165,7 @@ export default function SettingsScreen() {
             setHasPeanutAllergyGlobal(hasPeanutAllergy);
             setHasSesameAllergyGlobal(hasSesameAllergy);
             setHasSoyAllergyGlobal(hasSoyAllergy);
+            setHasSulfitesAllergyGlobal(hasSulfitesAllergy),
             setHasTreenutAllergyGlobal(hasTreenutAllergy);
             setHasWheatAllergyGlobal(hasWheatAllergy);
             setHasGlutenAllergyGlobal(hasGlutenAllergy);
@@ -267,6 +273,7 @@ export default function SettingsScreen() {
         setHasPeanutAllergyGlobal(false);
         setHasSesameAllergyGlobal(false);
         setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergy(false);
         setHasTreenutAllergyGlobal(false);
         setHasWheatAllergyGlobal(false);
         setHasGlutenAllergyGlobal(false);
@@ -430,6 +437,18 @@ export default function SettingsScreen() {
                             <Switch id="hasSoyAllergySwitch" style={styles.switch}
                                 value={hasSoyAllergy}
                                 onValueChange={setHasSoyAllergy}/>
+                        </View>
+                    </View>
+
+                    <View id="hasSulfitesAllergyOuterView" style={styles.settingsSwitchRow}>
+                        <Text id="hasSulfitesAllergyText" style={styles.label}>
+                            Do you have an allergy or intolerance to <Text style={{ fontWeight: 'bold' }}>sulfites</Text>?
+                        </Text>
+
+                        <View id="hasSulfitesAllergyInnerView" style={styles.switchContainer}>
+                            <Switch id="hasSulfitesAllergySwitch" style={styles.switch}
+                                value={hasSulfitesAllergy}
+                                onValueChange={setHasSulfitesAllergy}/>
                         </View>
                     </View>
 

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -48,24 +48,23 @@ export default function StatisticsScreen() {
         Variables and setters used to store a copy of the logged-in user's username and profile settings
         (Frontend copy updated based on the backend data)
     */
-    const 
-        {
-            usernameGlobal,
-            setUsernameGlobal,
-            setShowStatsGlobal,
-            setHasEggAllergyGlobal,
-            setHasFishOrShellfishAllergyGlobal,
-            setHasDairyIntoleranceGlobal,
-            setHasMilkAllergyGlobal,
-            setHasPeanutAllergyGlobal,
-            setHasSesameAllergyGlobal,
-            setHasSoyAllergyGlobal,
-            setHasTreenutAllergyGlobal,
-            setHasWheatAllergyGlobal,
-            setHasGlutenAllergyGlobal,
-            setIsVeganGlobal,
-            setIsVegetarianGlobal,
-            setPrefersHalalGlobal
+    const {
+        usernameGlobal,
+        setUsernameGlobal,
+        setHasDairyIntoleranceGlobal,            
+        setHasEggAllergyGlobal,
+        setHasFishOrShellfishAllergyGlobal,
+        setHasGlutenAllergyGlobal,
+        setHasMilkAllergyGlobal,
+        setHasPeanutAllergyGlobal,
+        setHasSesameAllergyGlobal,
+        setHasSulfitesAllergyGlobal,
+        setHasSoyAllergyGlobal,
+        setHasTreenutAllergyGlobal,
+        setHasWheatAllergyGlobal,
+        setIsVeganGlobal,
+        setIsVegetarianGlobal,
+        setPrefersHalalGlobal
 
         } = useUser();
 
@@ -325,22 +324,22 @@ export default function StatisticsScreen() {
     }
 
     /*
-        Log out the logged-in user by setting their username and profile settings to null, 
+        Log out the logged-in user by setting their profile settings to false, and routing to the splash page
     */
-    const logout = () => {
-
+    const logout = () => { 
+        
         setUsernameGlobal('');
-        setShowStatsGlobal(false);
+        setHasDairyIntoleranceGlobal(false);        
         setHasEggAllergyGlobal(false);
         setHasFishOrShellfishAllergyGlobal(false);
-        setHasDairyIntoleranceGlobal(false);
+        setHasGlutenAllergyGlobal(false);
         setHasMilkAllergyGlobal(false);
         setHasPeanutAllergyGlobal(false);
         setHasSesameAllergyGlobal(false);
         setHasSoyAllergyGlobal(false);
+        setHasSulfitesAllergyGlobal(false);
         setHasTreenutAllergyGlobal(false);
         setHasWheatAllergyGlobal(false);
-        setHasGlutenAllergyGlobal(false);
         setIsVeganGlobal(false);
         setIsVegetarianGlobal(false);
         setPrefersHalalGlobal(false);

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -35,7 +35,7 @@ export default function StatisticsScreen() {
     */
     const [fetchedStatistics, setFetchedStatistics] = useState(false);
     
-    const [isBackPressed, setIsBackPressed] = useState(false);
+    const [isHomeOrSplashPressed, setIsHomeOrSplashPressed] = useState(false);
     const [isLoginLogoutPressed, setIsLoginLogoutPressed] = useState(false);
     const [isDailyPressed, setIsDailyPressed] = useState(false);
     const [isAggregatePressed, setIsAggregatePressed] = useState(false);
@@ -456,14 +456,14 @@ export default function StatisticsScreen() {
             <View id="viewStatisticsStatusbar" style={styles.statusbar}>
 
                 {/* Route the user to the 'home' page or the 'splash' page */}
-                <TouchableOpacity id="backButton"
-                    style={[styles.headerButtonDefault, {backgroundColor: isBackPressed ? '#666666' : '#131312'}]}
-                    onPressIn={() => setIsBackPressed(true)}
-                    onPressOut={() => setIsBackPressed(false)}
+                <TouchableOpacity id="homeOrSplashButton"
+                    style={[styles.headerButtonDefault, {backgroundColor: isHomeOrSplashPressed ? '#666666' : '#131312'}]}
+                    onPressIn={() => setIsHomeOrSplashPressed(true)}
+                    onPressOut={() => setIsHomeOrSplashPressed(false)}
                     onPress={() => usernameGlobal != '' ? router.push('/home') : router.push('/')}>
 
-                    <Text id="backButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
-                        Back
+                    <Text id="homeOrSplashButtonText" style={styles.headerButtonTextDefault} numberOfLines={1}>
+                        Home
                     </Text>
                 </TouchableOpacity>
 


### PR DESCRIPTION
# Description

- Updated the home frontend page.
- The Settings button is now in the header.
- The Browse Food and Browse Dining buttons are now hidden behind a generic Browse button.

- Changed the Back button in the header of each frontend page to a Home button (The button still directs users to the same pages, but "Home" is less likely to mislead users than "Back").

- Added the sulfites attribute and the sulfites allergy to the frontend pages, allowing the app to display contains/may-contain sulfites warnings.

- When a user who is not logged-in uses the app, the allergies and intolerances in the frontend context will be set to true, allowing for more warnings to be displayed when the user is scanning food items, browsing food items, and browsing dining locations.

Fixes # (issue)

- https://github.com/GAchuzia/cu-bytes/issues/151
- https://github.com/GAchuzia/cu-bytes/issues/163

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [X] Manual tests
- [ ] Linted/formatted

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
