### PR TITLE
Fix/frontend comparative stats and food item notes

### DIFF
--- a/frontend/cu-bytes/app/dining.tsx
+++ b/frontend/cu-bytes/app/dining.tsx
@@ -297,11 +297,11 @@ export default function DiningScreen() {
             { field_name: "Calories", field_value: processFoodItemCalories(foodItem["calories"]) },
             { field_name: "Location", field_value: foodItem["dining_location"] },
             { field_name: "Cost", field_value: "$ " + processFoodItemCost(foodItem["cost"]) },
-            { field_name: "Carbs", field_value: processFoodItemCarbs(foodItem["carbs_g"]) + " grams" },
-            { field_name: "Fat", field_value: processFoodItemFat(foodItem["fat_g"]) + " grams" },
-            { field_name: "Fiber", field_value: processFoodItemFiber(foodItem["fiber_g"]) + " grams" },
-            { field_name: "Proteins", field_value: processFoodItemProteins(foodItem["proteins_g"]) + " grams" },
-            { field_name: "Sugar", field_value: processFoodItemSugar(foodItem["sugar_g"]) + " grams" }
+            { field_name: "Carbs", field_value: processFoodItemCarbs(foodItem["carbs_g"]) + " grams*" },
+            { field_name: "Fat", field_value: processFoodItemFat(foodItem["fat_g"]) + " grams*" },
+            { field_name: "Fiber", field_value: processFoodItemFiber(foodItem["fiber_g"]) + " grams*" },
+            { field_name: "Proteins", field_value: processFoodItemProteins(foodItem["proteins_g"]) + " grams*" },
+            { field_name: "Sugar", field_value: processFoodItemSugar(foodItem["sugar_g"]) + " grams*" }
         ]
     }
 
@@ -757,6 +757,10 @@ export default function DiningScreen() {
                                 </View>
                             )}>
                         </FlatList>
+
+                        <Text id="noteInfoText" style={styles.listRowText}>
+                            * = estimate from USDA food database 
+                        </Text>
                     </View>
                 )}
 

--- a/frontend/cu-bytes/app/enter.tsx
+++ b/frontend/cu-bytes/app/enter.tsx
@@ -190,11 +190,11 @@ export default function EnterScreen() {
             { field_name: "Calories", field_value: processFoodItemAttribute(foodItem["calories"]) },
             { field_name: "Location", field_value: foodItem["dining_location"] },
             { field_name: "Cost", field_value: "$ " + processFoodItemAttribute(foodItem["cost"]) },
-            { field_name: "Carbs", field_value: processFoodItemAttribute(foodItem["carbs_g"]) + " grams" },
-            { field_name: "Fat", field_value: processFoodItemAttribute(foodItem["fat_g"]) + " grams" },
-            { field_name: "Fiber", field_value: processFoodItemAttribute(foodItem["fiber_g"]) + " grams" },
-            { field_name: "Proteins", field_value: processFoodItemAttribute(foodItem["proteins_g"]) + " grams" },
-            { field_name: "Sugar", field_value: processFoodItemAttribute(foodItem["sugar_g"]) + " grams" }
+            { field_name: "Carbs", field_value: processFoodItemAttribute(foodItem["carbs_g"]) + " grams*" },
+            { field_name: "Fat", field_value: processFoodItemAttribute(foodItem["fat_g"]) + " grams*" },
+            { field_name: "Fiber", field_value: processFoodItemAttribute(foodItem["fiber_g"]) + " grams*" },
+            { field_name: "Proteins", field_value: processFoodItemAttribute(foodItem["proteins_g"]) + " grams*" },
+            { field_name: "Sugar", field_value: processFoodItemAttribute(foodItem["sugar_g"]) + " grams*" }
         ]
     }
 
@@ -535,6 +535,10 @@ export default function EnterScreen() {
                                 </View>
                             )}>
                         </FlatList>
+
+                        <Text id="noteInfoText" style={styles.listRowText}>
+                            * = estimate from USDA food database 
+                        </Text>
                     </View>
                 )}
 

--- a/frontend/cu-bytes/app/scan.tsx
+++ b/frontend/cu-bytes/app/scan.tsx
@@ -244,11 +244,11 @@ export default function ScanScreen() {
             { field_name: "Name", field_value: foodItem["food_name"]},
             { field_name: "Confidence", field_value: foodItem["confidence"] + " %" },
             { field_name: "Calories", field_value: processFoodItemAttribute(foodItem["calories"]) },
-            { field_name: "Carbs", field_value: processFoodItemAttribute(foodItem["carbs_g"]) + " grams" },
-            { field_name: "Fat", field_value: processFoodItemAttribute(foodItem["fat_g"]) + " grams" },
-            { field_name: "Fiber", field_value: processFoodItemAttribute(foodItem["fiber_g"]) + " grams" },
-            { field_name: "Proteins", field_value: processFoodItemAttribute(foodItem["proteins_g"]) + " grams" },
-            { field_name: "Sugar", field_value: processFoodItemAttribute(foodItem["sugar_g"]) + " grams" }
+            { field_name: "Carbs", field_value: processFoodItemAttribute(foodItem["carbs_g"]) + " grams*" },
+            { field_name: "Fat", field_value: processFoodItemAttribute(foodItem["fat_g"]) + " grams*" },
+            { field_name: "Fiber", field_value: processFoodItemAttribute(foodItem["fiber_g"]) + " grams*" },
+            { field_name: "Proteins", field_value: processFoodItemAttribute(foodItem["proteins_g"]) + " grams*" },
+            { field_name: "Sugar", field_value: processFoodItemAttribute(foodItem["sugar_g"]) + " grams*" }
         ]
     }
 
@@ -267,11 +267,11 @@ export default function ScanScreen() {
             { field_name: "Calories", field_value: processFoodItemAttribute(foodItem["calories"]) },
             { field_name: "Location", field_value: foodItem["dining_location"] },
             { field_name: "Cost", field_value: "$ " + processFoodItemAttribute(foodItem["cost"]) },
-            { field_name: "Carbs", field_value: processFoodItemAttribute(foodItem["carbs_g"]) + " grams" },
-            { field_name: "Fat", field_value: processFoodItemAttribute(foodItem["fat_g"]) + " grams" },
-            { field_name: "Fiber", field_value: processFoodItemAttribute(foodItem["fiber_g"]) + " grams" },
-            { field_name: "Proteins", field_value: processFoodItemAttribute(foodItem["proteins_g"]) + " grams" },
-            { field_name: "Sugar", field_value: processFoodItemAttribute(foodItem["sugar_g"]) + " grams" }
+            { field_name: "Carbs", field_value: processFoodItemAttribute(foodItem["carbs_g"]) + " grams*" },
+            { field_name: "Fat", field_value: processFoodItemAttribute(foodItem["fat_g"]) + " grams*" },
+            { field_name: "Fiber", field_value: processFoodItemAttribute(foodItem["fiber_g"]) + " grams*" },
+            { field_name: "Proteins", field_value: processFoodItemAttribute(foodItem["proteins_g"]) + " grams*" },
+            { field_name: "Sugar", field_value: processFoodItemAttribute(foodItem["sugar_g"]) + " grams*" }
         ]
     }
 
@@ -735,6 +735,9 @@ export default function ScanScreen() {
                             )}>
                         </FlatList>
 
+                        <Text id="noteInfoText" style={styles.listRowText}>
+                            * = estimate from USDA food database 
+                        </Text>
                     </View>
                 )}
 
@@ -754,7 +757,10 @@ export default function ScanScreen() {
                                 </View>
                             )}>
                         </FlatList>
-
+                        
+                        <Text id="noteInfoText" style={styles.listRowText}>
+                            Allergy information on this page is derived from an aggregation of Carleton data, and may not be entirely accurate
+                        </Text>
                     </View>
                 )}
 
@@ -939,6 +945,9 @@ export default function ScanScreen() {
                             )}>
                         </FlatList>
 
+                        <Text id="noteInfoText" style={styles.listRowText}>
+                            * = estimate from USDA food database 
+                        </Text>
                     </View>
                 )}
 
@@ -956,7 +965,6 @@ export default function ScanScreen() {
                                 </View>
                             )}>
                         </FlatList>
-
                     </View>
                 )}
 

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -312,16 +312,16 @@ export default function StatisticsScreen() {
         return [
             { field_name: "Balanced Food Groups Percentile", field_value: stats["balanced_food_groups_percentile"] },
             { field_name: "Balanced Macronutrients Percentile", field_value: stats["balanced_macronutrients_percentile"] },
-            { field_name: "Food Logging Percentile", field_value: stats["food_logging_percentile"] },
+            { field_name: "Number of Days Active", field_value: stats["checkin_percentile"] + ' day(s)' },            
+            { field_name: "Number of Items Logged", field_value: stats["food_logging_percentile"] + ' item(s)' },
             { field_name: "Carbs Percentile", field_value: stats["carbs_percentile"] },
-            { field_name: "Chicken Percentile", field_value: stats["checkin_percentile"] },
-            { field_name: "Dairy Percentile", field_value: stats["dairy_percentile"] },
             { field_name: "Fat Percentile", field_value: stats["fat_percentile"] },
             { field_name: "Fiber Percentile", field_value: stats["fiber_percentile"] },
+            { field_name: "Protein Percentile", field_value: stats["protein_fg_percentile"] },
+            { field_name: "Sugar Percentile", field_value: stats["sugar_percentile"] },
+            { field_name: "Dairy Percentile", field_value: stats["dairy_percentile"] },
             { field_name: "Fruits / Vegs Percentile", field_value: stats["fruits_veg_percentile"] },
             { field_name: "Grain Percentile", field_value: stats["grain_percentile"] },
-            { field_name: "Protein Percentile", field_value: stats["protein_fg_percentile"] },
-            { field_name: "Sugar Percentile", field_value: stats["sugar_percentile"] }
         ]
     }
 

--- a/frontend/cu-bytes/app/statistics.tsx
+++ b/frontend/cu-bytes/app/statistics.tsx
@@ -310,10 +310,10 @@ export default function StatisticsScreen() {
     const processComparativeStatistics = (stats: any) => {
 
         return [
-            { field_name: "Balanced Food Groups Percentile", field_value: stats["balanced_food_groups_percentile"] },
-            { field_name: "Balanced Macronutrients Percentile", field_value: stats["balanced_macronutrients_percentile"] },
             { field_name: "Number of Days Active", field_value: stats["checkin_percentile"] + ' day(s)' },            
-            { field_name: "Number of Items Logged", field_value: stats["food_logging_percentile"] + ' item(s)' },
+            { field_name: "Number of Items Logged", field_value: stats["food_logging_percentile"] + ' item(s)' },   
+            { field_name: "Balanced Macronutrients Percentile", field_value: stats["balanced_macronutrients_percentile"] },                     
+            { field_name: "Balanced Food Groups Percentile", field_value: stats["balanced_food_groups_percentile"] },
             { field_name: "Carbs Percentile", field_value: stats["carbs_percentile"] },
             { field_name: "Fat Percentile", field_value: stats["fat_percentile"] },
             { field_name: "Fiber Percentile", field_value: stats["fiber_percentile"] },


### PR DESCRIPTION
# Description

On the statistics frontend page, for the comparative statistics:
- "Food Logging" field was renamed to "Number of Items Logged"
- "Chicken" field was renamed to "Number of Days Active"

The fields were also reorganized to the following:
"Number of Days Active"          
"Number of Items Logged"
"Balanced Macronutrients Percentile"
"Balanced Food Groups Percentile"
"Carbs Percentile"
"Fat Percentile"
"Fiber Percentile"
"Protein Percentile"
"Sugar Percentile"
"Dairy Percentile"
"Fruits / Vegs Percentile"
"Grain Percentile"

On the scan food page, display the message:
"Allergy information on this page is derived from an aggregation of Carleton data, and may not be entirely accurate"
When an image of a food item is scanned.

On the scan food page, browse food items page, and browse dining locations page, display the message:
"* = estimate from USDA food database"
When scanning a food item, browsing similar food items, browsing food items by name, or browsing food items by dining location.

Fixes # (issue)

- https://github.com/GAchuzia/cu-bytes/issues/153
- https://github.com/GAchuzia/cu-bytes/issues/170

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [X] Manual tests
- [ ] Linted/formatted

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
